### PR TITLE
feat: frontend pages — dashboard, storybank, practice, mock, prep, progress, materials

### DIFF
--- a/frontend/src/components/MockSession.tsx
+++ b/frontend/src/components/MockSession.tsx
@@ -1,0 +1,120 @@
+import '../pages/pages.css';
+import { VoiceRecorder } from './VoiceRecorder';
+import type { MockFormat, MockQuestion } from '../hooks/useMock';
+
+interface MockSessionProps {
+  format: MockFormat;
+  currentQuestion: MockQuestion;
+  isRecording: boolean;
+  elapsedSeconds: number;
+  onToggleRecording: () => void;
+  onSkip: () => void;
+  onNext: () => void;
+  onEnd: () => void;
+}
+
+export function MockSession({
+  format,
+  currentQuestion,
+  isRecording,
+  elapsedSeconds,
+  onToggleRecording,
+  onSkip,
+  onNext,
+  onEnd,
+}: MockSessionProps) {
+  const isLastQuestion =
+    currentQuestion.questionNumber === currentQuestion.totalQuestions;
+
+  return (
+    <div className="card">
+      <div className="card-header">
+        <span className="card-title">
+          <svg
+            className="icon"
+            viewBox="0 0 18 18"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <rect x="6" y="1" width="6" height="10" rx="3" />
+            <path d="M3 8a6 6 0 0 0 12 0" />
+            <line x1="9" y1="14" x2="9" y2="17" />
+            <line x1="6" y1="17" x2="12" y2="17" />
+          </svg>
+          {format.name} Interview
+        </span>
+        <span className="tag tag-primary">
+          {currentQuestion.questionNumber} / {currentQuestion.totalQuestions}
+        </span>
+      </div>
+      <div className="card-body">
+        {/* Progress indicator */}
+        <div
+          style={{
+            display: 'flex',
+            gap: 4,
+            marginBottom: 20,
+          }}
+        >
+          {Array.from({ length: currentQuestion.totalQuestions }).map((_, i) => (
+            <div
+              key={i}
+              style={{
+                flex: 1,
+                height: 4,
+                borderRadius: 2,
+                background:
+                  i < currentQuestion.questionNumber
+                    ? 'var(--primary)'
+                    : 'var(--border)',
+                transition: 'background 0.2s',
+              }}
+            />
+          ))}
+        </div>
+
+        <div className="voice-area">
+          {/* Question Display */}
+          <div className="voice-question">
+            <div className="voice-question-label">{currentQuestion.label}</div>
+            <div className="voice-question-text">{currentQuestion.text}</div>
+          </div>
+
+          {/* Voice Recorder */}
+          <VoiceRecorder
+            isRecording={isRecording}
+            onToggle={onToggleRecording}
+            elapsedSeconds={elapsedSeconds}
+          />
+
+          {/* Controls */}
+          <div className="voice-controls">
+            <button className="btn btn-outline btn-sm" onClick={onSkip}>
+              Skip
+            </button>
+            {!isLastQuestion ? (
+              <button className="btn btn-primary btn-sm" onClick={onNext}>
+                Next Question
+              </button>
+            ) : (
+              <button className="btn btn-primary btn-sm" onClick={onEnd}>
+                Finish Interview
+              </button>
+            )}
+          </div>
+
+          <button
+            className="btn btn-outline btn-sm"
+            style={{ marginTop: 8, color: 'var(--text-muted)' }}
+            onClick={onEnd}
+          >
+            End Interview Early
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ResumeUpload.tsx
+++ b/frontend/src/components/ResumeUpload.tsx
@@ -1,0 +1,34 @@
+import { useRef } from 'react';
+
+interface ResumeUploadProps {
+  onUpload: (file: File) => void;
+}
+
+export function ResumeUpload({ onUpload }: ResumeUploadProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".pdf,.docx"
+        style={{ display: 'none' }}
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) {
+            onUpload(file);
+          }
+          // Reset so same file can be re-selected
+          e.target.value = '';
+        }}
+      />
+      <button
+        className="btn btn-primary btn-sm"
+        onClick={() => inputRef.current?.click()}
+      >
+        Upload Resume
+      </button>
+    </>
+  );
+}

--- a/frontend/src/components/ScoreTrendChart.tsx
+++ b/frontend/src/components/ScoreTrendChart.tsx
@@ -1,0 +1,146 @@
+import type { ScoreHistoryPoint } from '../hooks/useProgress';
+
+interface ScoreTrendChartProps {
+  data: ScoreHistoryPoint[];
+  filter: string;
+  onFilterChange: (filter: string) => void;
+}
+
+type DimensionKey = 'substance' | 'structure' | 'relevance' | 'credibility' | 'differentiation';
+
+const DIMENSIONS: { key: DimensionKey; label: string; color: string; dashed?: boolean }[] = [
+  { key: 'substance', label: 'Substance', color: 'var(--c-substance)' },
+  { key: 'structure', label: 'Structure', color: 'var(--c-structure)' },
+  { key: 'relevance', label: 'Relevance', color: 'var(--c-relevance)' },
+  { key: 'credibility', label: 'Credibility', color: 'var(--c-credibility)' },
+  { key: 'differentiation', label: 'Differentiation', color: 'var(--c-differentiation)', dashed: true },
+];
+
+const FILTERS = [
+  { value: 'all', label: 'All' },
+  { value: 'google', label: 'Google' },
+  { value: 'practice', label: 'Practice' },
+];
+
+/** Map a score (1-5) to an SVG Y coordinate within viewBox 0-180 */
+function scoreToY(score: number): number {
+  return 180 - ((score - 1) / 4) * 140 - 20;
+}
+
+/** Spread N points evenly from x=30 to x=370 */
+function indexToX(index: number, total: number): number {
+  if (total <= 1) return 200;
+  return 30 + (index / (total - 1)) * 340;
+}
+
+function buildPolyline(data: ScoreHistoryPoint[], dimension: DimensionKey): string {
+  return data
+    .map((point, i) => {
+      const x = Math.round(indexToX(i, data.length));
+      const y = Math.round(scoreToY(point[dimension]));
+      return `${x},${y}`;
+    })
+    .join(' ');
+}
+
+export function ScoreTrendChart({ data, filter, onFilterChange }: ScoreTrendChartProps) {
+  return (
+    <>
+      {/* Filter chips */}
+      <div className="card-header">
+        <span className="card-title">Score Trends</span>
+        <div style={{ display: 'flex', gap: 6 }}>
+          {FILTERS.map((f) => (
+            <span
+              key={f.value}
+              className={`tag ${filter === f.value ? 'tag-primary' : 'tag-neutral'}`}
+              style={{ cursor: 'pointer' }}
+              onClick={() => onFilterChange(f.value)}
+            >
+              {f.label}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="card-body">
+        {/* SVG Chart */}
+        <svg viewBox="0 0 380 180" style={{ width: '100%' }}>
+          {/* Horizontal grid lines */}
+          {[20, 60, 100, 140].map((y) => (
+            <line
+              key={y}
+              x1={25}
+              y1={y}
+              x2={370}
+              y2={y}
+              stroke="var(--border-light)"
+              strokeWidth={0.5}
+            />
+          ))}
+
+          {/* Y-axis labels */}
+          {[
+            { y: 24, label: '5' },
+            { y: 64, label: '4' },
+            { y: 104, label: '3' },
+            { y: 144, label: '2' },
+          ].map((item) => (
+            <text
+              key={item.label}
+              x={14}
+              y={item.y}
+              fontSize={9}
+              fill="var(--text-muted)"
+              textAnchor="end"
+              fontFamily="var(--ff-body)"
+            >
+              {item.label}
+            </text>
+          ))}
+
+          {/* Dimension polylines */}
+          {data.length > 0 &&
+            DIMENSIONS.map((dim) => (
+              <polyline
+                key={dim.key}
+                points={buildPolyline(data, dim.key)}
+                fill="none"
+                stroke={dim.color}
+                strokeWidth={2}
+                strokeDasharray={dim.dashed ? '4 3' : undefined}
+              />
+            ))}
+
+          {/* End dots for each dimension */}
+          {data.length > 0 &&
+            DIMENSIONS.map((dim) => {
+              const lastIndex = data.length - 1;
+              const lastPoint = data[lastIndex];
+              const cx = Math.round(indexToX(lastIndex, data.length));
+              const cy = Math.round(scoreToY(lastPoint[dim.key]));
+              return (
+                <circle
+                  key={`dot-${dim.key}`}
+                  cx={cx}
+                  cy={cy}
+                  r={3}
+                  fill={dim.color}
+                />
+              );
+            })}
+        </svg>
+
+        {/* Legend */}
+        <div className="chart-legend">
+          {DIMENSIONS.map((dim) => (
+            <span key={dim.key} className="chart-legend-item">
+              <span className="chart-legend-dot" style={{ background: dim.color }} />
+              {' '}{dim.label}
+            </span>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/Scorecard.tsx
+++ b/frontend/src/components/Scorecard.tsx
@@ -1,0 +1,56 @@
+import '../pages/pages.css';
+
+interface ScorecardProps {
+  scores: {
+    substance: number;
+    structure: number;
+    relevance: number;
+    credibility: number;
+    differentiation: number;
+  };
+  hireSignal: string;
+  feedback: string;
+}
+
+const DIMENSIONS: { key: keyof ScorecardProps['scores']; label: string; color: string }[] = [
+  { key: 'substance', label: 'Substance', color: 'var(--c-substance)' },
+  { key: 'structure', label: 'Structure', color: 'var(--c-structure)' },
+  { key: 'relevance', label: 'Relevance', color: 'var(--c-relevance)' },
+  { key: 'credibility', label: 'Credibility', color: 'var(--c-credibility)' },
+  { key: 'differentiation', label: 'Differentiation', color: 'var(--c-differentiation)' },
+];
+
+export function Scorecard({ scores, hireSignal, feedback }: ScorecardProps) {
+  return (
+    <div className="scorecard">
+      <div className="score-dims">
+        {DIMENSIONS.map((dim) => {
+          const value = scores[dim.key];
+          const widthPercent = (value / 5) * 100;
+          return (
+            <div className="score-dim" key={dim.key}>
+              <span className="score-dim-label">{dim.label}</span>
+              <div className="score-dim-bar">
+                <div
+                  className="score-dim-fill"
+                  style={{ width: `${widthPercent}%`, background: dim.color }}
+                />
+              </div>
+              <span className="score-dim-val">{value.toFixed(1)}</span>
+            </div>
+          );
+        })}
+      </div>
+      <div>
+        <div style={{ marginBottom: 12 }}>
+          <span className="tag tag-green" style={{ fontSize: 13, fontWeight: 700 }}>
+            {hireSignal}
+          </span>
+        </div>
+        <p style={{ fontSize: 13, lineHeight: 1.7, color: 'var(--text-secondary)' }}>
+          {feedback}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/StoryForm.tsx
+++ b/frontend/src/components/StoryForm.tsx
@@ -1,0 +1,293 @@
+import { useState } from 'react';
+
+interface StoryFormProps {
+  onSave: (data: StoryFormData) => void;
+  onCancel: () => void;
+}
+
+export interface StoryFormData {
+  title: string;
+  situation: string;
+  task: string;
+  action: string;
+  result: string;
+  primarySkill: string;
+  secondarySkill: string;
+  earnedSecret: string;
+  strength: number;
+  domain: string;
+  deployFor: string;
+  notes: string;
+}
+
+const EMPTY_FORM: StoryFormData = {
+  title: '',
+  situation: '',
+  task: '',
+  action: '',
+  result: '',
+  primarySkill: '',
+  secondarySkill: '',
+  earnedSecret: '',
+  strength: 3,
+  domain: '',
+  deployFor: '',
+  notes: '',
+};
+
+export function StoryForm({ onSave, onCancel }: StoryFormProps) {
+  const [form, setForm] = useState<StoryFormData>(EMPTY_FORM);
+
+  const update = (field: keyof StoryFormData, value: string | number) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSave(form);
+  };
+
+  return (
+    <div className="card" style={{ marginBottom: 14 }}>
+      <div className="card-header">
+        <span className="card-title">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 18 18"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="icon"
+          >
+            <line x1="9" y1="3" x2="9" y2="15" />
+            <line x1="3" y1="9" x2="15" y2="9" />
+          </svg>{' '}
+          Add New Story
+        </span>
+      </div>
+      <div className="card-body">
+        <form onSubmit={handleSubmit} style={{ display: 'grid', gap: 12 }}>
+          {/* Title */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)' }}>
+              Title
+            </label>
+            <input
+              type="text"
+              value={form.title}
+              onChange={(e) => update('title', e.target.value)}
+              placeholder="e.g. Scaling Eng Org 8 to 27"
+              style={{
+                padding: '8px 10px',
+                border: '1px solid var(--border)',
+                borderRadius: 'var(--radius-sm)',
+                fontSize: 13,
+                fontFamily: 'var(--ff-body)',
+                background: 'var(--bg)',
+              }}
+            />
+          </div>
+
+          {/* STAR fields */}
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: 12,
+            }}
+          >
+            {(['situation', 'task', 'action', 'result'] as const).map((field) => (
+              <div key={field} style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)', textTransform: 'capitalize' }}>
+                  {field}
+                </label>
+                <textarea
+                  value={form[field]}
+                  onChange={(e) => update(field, e.target.value)}
+                  placeholder={`Describe the ${field}...`}
+                  rows={3}
+                  style={{
+                    padding: '8px 10px',
+                    border: '1px solid var(--border)',
+                    borderRadius: 'var(--radius-sm)',
+                    fontSize: 13,
+                    fontFamily: 'var(--ff-body)',
+                    background: 'var(--bg)',
+                    resize: 'vertical',
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+
+          {/* Skill / Secret row */}
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 12 }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)' }}>
+                Primary Skill
+              </label>
+              <input
+                type="text"
+                value={form.primarySkill}
+                onChange={(e) => update('primarySkill', e.target.value)}
+                placeholder="e.g. Team Building"
+                style={{
+                  padding: '8px 10px',
+                  border: '1px solid var(--border)',
+                  borderRadius: 'var(--radius-sm)',
+                  fontSize: 13,
+                  fontFamily: 'var(--ff-body)',
+                  background: 'var(--bg)',
+                }}
+              />
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)' }}>
+                Secondary Skill
+              </label>
+              <input
+                type="text"
+                value={form.secondarySkill}
+                onChange={(e) => update('secondarySkill', e.target.value)}
+                placeholder="e.g. Change Mgmt"
+                style={{
+                  padding: '8px 10px',
+                  border: '1px solid var(--border)',
+                  borderRadius: 'var(--radius-sm)',
+                  fontSize: 13,
+                  fontFamily: 'var(--ff-body)',
+                  background: 'var(--bg)',
+                }}
+              />
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)' }}>
+                Earned Secret
+              </label>
+              <input
+                type="text"
+                value={form.earnedSecret}
+                onChange={(e) => update('earnedSecret', e.target.value)}
+                placeholder="Your unique insight..."
+                style={{
+                  padding: '8px 10px',
+                  border: '1px solid var(--border)',
+                  borderRadius: 'var(--radius-sm)',
+                  fontSize: 13,
+                  fontFamily: 'var(--ff-body)',
+                  background: 'var(--bg)',
+                }}
+              />
+            </div>
+          </div>
+
+          {/* Strength selector */}
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 12 }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)' }}>
+                Strength (1-5)
+              </label>
+              <div style={{ display: 'flex', gap: 6, alignItems: 'center', paddingTop: 4 }}>
+                {[1, 2, 3, 4, 5].map((n) => (
+                  <button
+                    key={n}
+                    type="button"
+                    onClick={() => update('strength', n)}
+                    style={{
+                      width: 28,
+                      height: 28,
+                      borderRadius: 'var(--radius-xs)',
+                      border: '1px solid var(--border)',
+                      background: n <= form.strength ? 'var(--primary)' : 'var(--bg)',
+                      color: n <= form.strength ? 'white' : 'var(--text-secondary)',
+                      cursor: 'pointer',
+                      fontSize: 12,
+                      fontWeight: 600,
+                      fontFamily: 'var(--ff-body)',
+                    }}
+                  >
+                    {n}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)' }}>
+                Domain
+              </label>
+              <input
+                type="text"
+                value={form.domain}
+                onChange={(e) => update('domain', e.target.value)}
+                placeholder="e.g. FinTech, SaaS"
+                style={{
+                  padding: '8px 10px',
+                  border: '1px solid var(--border)',
+                  borderRadius: 'var(--radius-sm)',
+                  fontSize: 13,
+                  fontFamily: 'var(--ff-body)',
+                  background: 'var(--bg)',
+                }}
+              />
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)' }}>
+                Deploy For
+              </label>
+              <input
+                type="text"
+                value={form.deployFor}
+                onChange={(e) => update('deployFor', e.target.value)}
+                placeholder="e.g. Leadership, Technical"
+                style={{
+                  padding: '8px 10px',
+                  border: '1px solid var(--border)',
+                  borderRadius: 'var(--radius-sm)',
+                  fontSize: 13,
+                  fontFamily: 'var(--ff-body)',
+                  background: 'var(--bg)',
+                }}
+              />
+            </div>
+          </div>
+
+          {/* Notes */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)' }}>
+              Notes
+            </label>
+            <textarea
+              value={form.notes}
+              onChange={(e) => update('notes', e.target.value)}
+              placeholder="Any additional notes..."
+              rows={2}
+              style={{
+                padding: '8px 10px',
+                border: '1px solid var(--border)',
+                borderRadius: 'var(--radius-sm)',
+                fontSize: 13,
+                fontFamily: 'var(--ff-body)',
+                background: 'var(--bg)',
+                resize: 'vertical',
+              }}
+            />
+          </div>
+
+          {/* Buttons */}
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', paddingTop: 4 }}>
+            <button type="button" className="btn btn-outline btn-sm" onClick={onCancel}>
+              Cancel
+            </button>
+            <button type="submit" className="btn btn-primary btn-sm">
+              Save Story
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/VoiceRecorder.tsx
+++ b/frontend/src/components/VoiceRecorder.tsx
@@ -1,0 +1,44 @@
+import '../pages/pages.css';
+
+interface VoiceRecorderProps {
+  isRecording: boolean;
+  onToggle: () => void;
+  elapsedSeconds: number;
+}
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export function VoiceRecorder({ isRecording, onToggle, elapsedSeconds }: VoiceRecorderProps) {
+  return (
+    <>
+      <div className="voice-bars">
+        <span className="voice-bar"></span>
+        <span className="voice-bar"></span>
+        <span className="voice-bar"></span>
+        <span className="voice-bar"></span>
+        <span className="voice-bar"></span>
+        <span className="voice-bar"></span>
+        <span className="voice-bar"></span>
+      </div>
+
+      <button
+        className={`mic-btn${isRecording ? ' recording' : ''}`}
+        onClick={onToggle}
+        aria-label={isRecording ? 'Stop recording' : 'Start recording'}
+      >
+        <svg viewBox="0 0 18 18" width="32" height="32" fill="none" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="6" y="1" width="6" height="10" rx="3" />
+          <path d="M3 8a6 6 0 0 0 12 0" />
+          <line x1="9" y1="14" x2="9" y2="17" />
+          <line x1="6" y1="17" x2="12" y2="17" />
+        </svg>
+      </button>
+
+      <div className="voice-timer">{formatTime(elapsedSeconds)}</div>
+    </>
+  );
+}

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -1,0 +1,195 @@
+import { useQuery } from '@tanstack/react-query';
+
+/* ── Type definitions ── */
+
+export interface ProfileData {
+  name: string;
+  role: string;
+  track: string;
+  timeline: string;
+  mode: string;
+  concern: string;
+  tags: { label: string; variant: string }[];
+  initials: string;
+}
+
+export interface StoryData {
+  id: string;
+  title: string;
+  primarySkill: string;
+  strength: number; // 1-5
+  uses: number;
+}
+
+export interface ScorePoint {
+  session: number;
+  substance: number;
+  structure: number;
+  relevance: number;
+  credibility: number;
+  differentiation: number;
+}
+
+export interface KanbanWorkspace {
+  company: string;
+  role: string;
+  status: string;
+  fit: string;
+  color: string;
+  stage: 'researched' | 'applied' | 'interviewing' | 'offer';
+  tagBg: string;
+  tagColor: string;
+}
+
+export interface DrillProgression {
+  currentStage: number;
+  stages: string[];
+}
+
+export interface CoachingStrategy {
+  bottleneck: string;
+  approach: string;
+  calibration: string;
+}
+
+export interface ChecklistItem {
+  label: string;
+  done: boolean;
+}
+
+export interface RoundItem {
+  name: string;
+  meta: string;
+  status: 'completed' | 'upcoming' | 'pending';
+  number: number;
+}
+
+export interface JobDashboardData {
+  company: string;
+  role: string;
+  logoInitial: string;
+  fit: string;
+  status: string;
+  band: string;
+  nextRound: string;
+  fitConfidence: string;
+  storiesMapped: string;
+  prepChecklist: ChecklistItem[];
+  roundTimeline: RoundItem[];
+}
+
+export interface DashboardData {
+  profile: ProfileData;
+  stories: StoryData[];
+  scores: ScorePoint[];
+  workspaces: KanbanWorkspace[];
+  drillProgression: DrillProgression;
+  coachingStrategy: CoachingStrategy;
+  jobDashboard: JobDashboardData;
+}
+
+/* ── Mock data matching the reference HTML ── */
+
+const mockData: DashboardData = {
+  profile: {
+    name: 'Mayank Verma',
+    role: 'Director of Engineering, Product Engineering',
+    track: 'Full System',
+    timeline: '~2 months',
+    mode: 'Full coaching',
+    concern: 'Executive presence',
+    tags: [
+      { label: 'Full System', variant: 'tag-primary' },
+      { label: 'Level 5', variant: 'tag-neutral' },
+      { label: 'Stage 1', variant: 'tag-neutral' },
+      { label: 'May 2026', variant: 'tag-amber' },
+    ],
+    initials: 'MV',
+  },
+
+  stories: [
+    { id: 'S001', title: 'Scaling Eng 8 to 27 Post-Layoffs', primarySkill: 'Team Building', strength: 4, uses: 3 },
+    { id: 'S002', title: 'Voice AI Platform — 1M+ Calls', primarySkill: 'Technical Vision', strength: 5, uses: 5 },
+    { id: 'S003', title: '$200M Marketplace Platform', primarySkill: 'Business Impact', strength: 4, uses: 2 },
+    { id: 'S004', title: 'LLM Solutions Saving $10M+', primarySkill: 'Innovation', strength: 4, uses: 1 },
+  ],
+
+  scores: [
+    { session: 1, substance: 3.0, structure: 2.5, relevance: 3.5, credibility: 3.0, differentiation: 2.0 },
+    { session: 2, substance: 3.3, structure: 3.0, relevance: 3.6, credibility: 3.2, differentiation: 2.3 },
+    { session: 3, substance: 3.6, structure: 3.2, relevance: 4.0, credibility: 3.5, differentiation: 2.5 },
+    { session: 4, substance: 3.8, structure: 3.5, relevance: 4.0, credibility: 3.7, differentiation: 3.0 },
+    { session: 5, substance: 4.1, structure: 3.8, relevance: 4.2, credibility: 4.0, differentiation: 3.2 },
+    { session: 6, substance: 4.3, structure: 4.0, relevance: 4.5, credibility: 4.2, differentiation: 3.5 },
+  ],
+
+  workspaces: [
+    { company: 'Stripe', role: 'Sr. Dir., Platform Eng', status: 'Strong Fit', fit: 'strong', color: '#635BFF', stage: 'researched', tagBg: '#eeecfb', tagColor: '#5a4dbf' },
+    { company: 'Google', role: 'Dir. Eng, AI/ML', status: 'Round 2', fit: 'high', color: '#4285F4', stage: 'interviewing', tagBg: 'var(--primary-light)', tagColor: 'var(--primary-dark)' },
+    { company: 'Meta', role: 'Dir., Product Eng', status: 'Round 1', fit: 'medium', color: '#1877F2', stage: 'interviewing', tagBg: 'var(--primary-light)', tagColor: 'var(--primary-dark)' },
+  ],
+
+  drillProgression: {
+    currentStage: 1,
+    stages: ['Ladder', 'Pushback', 'Pivot', 'Gap', 'Role', 'Panel', 'Stress', 'Tech'],
+  },
+
+  coachingStrategy: {
+    bottleneck: 'TBD',
+    approach: 'Building foundation',
+    calibration: 'Uncalibrated',
+  },
+
+  jobDashboard: {
+    company: 'Google',
+    role: 'Director of Engineering, AI/ML',
+    logoInitial: 'G',
+    fit: 'Strong Fit',
+    status: 'Interviewing',
+    band: 'Executive Band',
+    nextRound: 'Mar 28 — System Design',
+    fitConfidence: 'High',
+    storiesMapped: '4/5 competencies',
+    prepChecklist: [
+      { label: 'Company research completed', done: true },
+      { label: 'JD decoded — 5 competencies identified', done: true },
+      { label: 'Prep brief generated', done: true },
+      { label: 'Stories mapped to top questions', done: true },
+      { label: 'Mock system design interview', done: false },
+      { label: 'Hype plan for interview day', done: false },
+    ],
+    roundTimeline: [
+      { name: 'R1: Behavioral Screen', meta: 'Mar 15 — 45 min, Recruiter — Advanced', status: 'completed', number: 1 },
+      { name: 'R2: System Design', meta: 'Mar 28 — 60 min, Hiring Manager', status: 'upcoming', number: 2 },
+      { name: 'R3: Bar Raiser', meta: 'TBD', status: 'pending', number: 3 },
+      { name: 'R4: Team Match', meta: 'TBD', status: 'pending', number: 4 },
+    ],
+  },
+};
+
+/* ── Hook ── */
+
+async function fetchDashboard(): Promise<DashboardData> {
+  // Simulate network delay for realistic loading state
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  return mockData;
+}
+
+export function useDashboard() {
+  const query = useQuery({
+    queryKey: ['dashboard'],
+    queryFn: fetchDashboard,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return {
+    profile: query.data?.profile ?? null,
+    stories: query.data?.stories ?? [],
+    scores: query.data?.scores ?? [],
+    workspaces: query.data?.workspaces ?? [],
+    drillProgression: query.data?.drillProgression ?? null,
+    coachingStrategy: query.data?.coachingStrategy ?? null,
+    jobDashboard: query.data?.jobDashboard ?? null,
+    isLoading: query.isLoading,
+  };
+}

--- a/frontend/src/hooks/useMaterials.ts
+++ b/frontend/src/hooks/useMaterials.ts
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+
+export type MaterialTab = 'resume' | 'linkedin' | 'pitch' | 'outreach' | 'salary';
+
+export interface ResumeFix {
+  severity: 'red' | 'amber' | 'neutral';
+  text: string;
+}
+
+export interface ResumeData {
+  grade: string;
+  dimensions: {
+    ats: string;
+    recruiterScan: string;
+    bulletQuality: string;
+    seniority: string;
+    keywords: string;
+  };
+  topFixes: ResumeFix[];
+}
+
+export interface PitchData {
+  hook10s: string;
+  fullStatement: string;
+}
+
+const MOCK_RESUME: ResumeData = {
+  grade: 'B+',
+  dimensions: {
+    ats: 'Ready',
+    recruiterScan: 'Strong',
+    bulletQuality: 'Moderate',
+    seniority: 'Aligned',
+    keywords: 'Moderate',
+  },
+  topFixes: [
+    {
+      severity: 'red',
+      text: 'DoorDash bullets lack quantification \u2014 add call volume, cost savings, timeline',
+    },
+    {
+      severity: 'amber',
+      text: 'Missing "Director-level" language \u2014 add strategy, portfolio, executive stakeholders',
+    },
+    {
+      severity: 'neutral',
+      text: 'Add a 2-line summary that anchors your positioning statement',
+    },
+  ],
+};
+
+const MOCK_PITCH: PitchData = {
+  hook10s:
+    '\u201CI build AI platforms that replace entire vendor ecosystems \u2014 my latest handles a million support calls a month at half the cost.\u201D',
+  fullStatement:
+    '\u201CI\u2019m an engineering leader who specializes in taking nascent AI capabilities and turning them into production platforms at scale. At DoorDash, I built a voice AI system from scratch that now handles over a million customer support calls monthly \u2014 50% cheaper than the vendor it replaced, with 25% fewer escalations. Before that, I spent 5 years at Lyft scaling a marketplace engineering org from 8 to 27 engineers across 4 countries, owning a $200M revenue platform. I\u2019m looking for a Director role where I can apply that same build-and-scale pattern to a bigger canvas.\u201D',
+};
+
+export function useMaterials(initialTab: MaterialTab = 'resume') {
+  const [activeTab, setActiveTab] = useState<MaterialTab>(initialTab);
+  const [isLoading] = useState(false);
+
+  const resume: ResumeData = MOCK_RESUME;
+  const linkedin: null = null;
+  const pitch: PitchData = MOCK_PITCH;
+  const outreach: null = null;
+  const salary: null = null;
+
+  return {
+    activeTab,
+    setActiveTab,
+    resume,
+    linkedin,
+    pitch,
+    outreach,
+    salary,
+    isLoading,
+  };
+}

--- a/frontend/src/hooks/useMock.ts
+++ b/frontend/src/hooks/useMock.ts
@@ -1,0 +1,209 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+export interface MockFormat {
+  id: string;
+  emoji: string;
+  name: string;
+  description: string;
+  totalQuestions: number;
+  durationMin: number;
+}
+
+export interface MockQuestion {
+  label: string;
+  text: string;
+  questionNumber: number;
+  totalQuestions: number;
+}
+
+const MOCK_FORMATS: MockFormat[] = [
+  {
+    id: 'behavioral-screen',
+    emoji: '\u{1F4AC}',
+    name: 'Behavioral Screen',
+    description: '4 questions, 30 min\nRecruiter-style',
+    totalQuestions: 4,
+    durationMin: 30,
+  },
+  {
+    id: 'deep-behavioral',
+    emoji: '\u{1F9E0}',
+    name: 'Deep Behavioral',
+    description: '6 questions, 45 min\nHiring manager depth',
+    totalQuestions: 6,
+    durationMin: 45,
+  },
+  {
+    id: 'system-design',
+    emoji: '\u{1F3AF}',
+    name: 'System Design',
+    description: 'Communication coaching\n60 min session',
+    totalQuestions: 4,
+    durationMin: 60,
+  },
+  {
+    id: 'panel',
+    emoji: '\u{1F465}',
+    name: 'Panel',
+    description: 'Multiple personas\n5 questions, 45 min',
+    totalQuestions: 5,
+    durationMin: 45,
+  },
+  {
+    id: 'bar-raiser',
+    emoji: '\u{26A1}',
+    name: 'Bar Raiser',
+    description: 'High-pressure\n6 questions, 50 min',
+    totalQuestions: 6,
+    durationMin: 50,
+  },
+  {
+    id: 'technical-behavioral',
+    emoji: '\u{1F504}',
+    name: 'Technical + Behavioral',
+    description: 'Mixed format\n5 questions, 45 min',
+    totalQuestions: 5,
+    durationMin: 45,
+  },
+];
+
+const SAMPLE_QUESTIONS: Record<string, string[]> = {
+  'behavioral-screen': [
+    'Tell me about yourself and why you are interested in this role.',
+    'Describe a time you had to influence a decision without having direct authority.',
+    'Give me an example of a project where you had to deal with ambiguity.',
+    'What is the most impactful thing you have accomplished in your career so far?',
+  ],
+  'deep-behavioral': [
+    'Walk me through a time you had to rebuild trust with a key stakeholder after a major setback.',
+    'Tell me about a time you made a difficult trade-off between speed and quality.',
+    'Describe a situation where you had to lead through significant organizational change.',
+    'Give me an example of when you had to deliver difficult feedback to a high performer.',
+    'Tell me about a time your team failed to meet a critical deadline. What did you do?',
+    'Describe how you have built and scaled a team from scratch.',
+  ],
+  'system-design': [
+    'Design a real-time notification system that scales to millions of users.',
+    'How would you architect a distributed job scheduling system?',
+    'Walk me through designing a content recommendation engine.',
+    'Design an API rate limiting service for a multi-tenant platform.',
+  ],
+  'panel': [
+    'How do you prioritize competing requests from multiple stakeholders?',
+    'Tell us about a time you drove alignment across engineering, product, and design.',
+    'Describe your approach to building an inclusive team culture.',
+    'Give an example of how you handled a major production incident.',
+    'What is your philosophy on technical debt and how do you manage it?',
+  ],
+  'bar-raiser': [
+    'Tell me about a time you had to make a critical decision with incomplete information under extreme time pressure.',
+    'Describe a situation where you disagreed with your leadership and what you did about it.',
+    'Give me an example of a time you had to pivot your entire strategy mid-execution.',
+    'How have you handled a situation where a team member was consistently underperforming?',
+    'Tell me about the most complex cross-functional initiative you have led.',
+    'Describe a time when you had to say no to a senior leader. How did you handle it?',
+  ],
+  'technical-behavioral': [
+    'Walk me through a complex system you designed and the key trade-offs you made.',
+    'Tell me about a time you had to debug a critical production issue under pressure.',
+    'How do you balance hands-on technical work with leadership responsibilities?',
+    'Describe a time you introduced a new technology or practice to your organization.',
+    'Give me an example of how you have mentored engineers to grow into senior roles.',
+  ],
+};
+
+export function useMock() {
+  const [selectedFormat, setSelectedFormat] = useState<string | null>(null);
+  const [sessionActive, setSessionActive] = useState(false);
+  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
+  const [isRecording, setIsRecording] = useState(false);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const activeFormat = MOCK_FORMATS.find((f) => f.id === selectedFormat) ?? null;
+
+  // Timer
+  useEffect(() => {
+    if (isRecording) {
+      intervalRef.current = setInterval(() => {
+        setElapsedSeconds((prev) => prev + 1);
+      }, 1000);
+    } else if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [isRecording]);
+
+  const currentQuestion: MockQuestion | null =
+    activeFormat && sessionActive
+      ? {
+          label: `Question ${currentQuestionIndex + 1} of ${activeFormat.totalQuestions} — ${activeFormat.name}`,
+          text:
+            SAMPLE_QUESTIONS[activeFormat.id]?.[currentQuestionIndex] ??
+            'Tell me about a challenging situation you faced and how you handled it.',
+          questionNumber: currentQuestionIndex + 1,
+          totalQuestions: activeFormat.totalQuestions,
+        }
+      : null;
+
+  const selectFormat = useCallback((id: string) => {
+    setSelectedFormat(id);
+  }, []);
+
+  const startSession = useCallback(() => {
+    setSessionActive(true);
+    setCurrentQuestionIndex(0);
+    setElapsedSeconds(0);
+    setIsRecording(false);
+    setIsLoading(false);
+  }, []);
+
+  const endSession = useCallback(() => {
+    setSessionActive(false);
+    setSelectedFormat(null);
+    setCurrentQuestionIndex(0);
+    setElapsedSeconds(0);
+    setIsRecording(false);
+    setIsLoading(false);
+  }, []);
+
+  const toggleRecording = useCallback(() => {
+    setIsRecording((prev) => !prev);
+  }, []);
+
+  const nextQuestion = useCallback(() => {
+    if (!activeFormat) return;
+    setIsRecording(false);
+    setElapsedSeconds(0);
+    if (currentQuestionIndex + 1 < activeFormat.totalQuestions) {
+      setCurrentQuestionIndex((prev) => prev + 1);
+    }
+  }, [activeFormat, currentQuestionIndex]);
+
+  const skipQuestion = useCallback(() => {
+    nextQuestion();
+  }, [nextQuestion]);
+
+  return {
+    formats: MOCK_FORMATS,
+    selectedFormat,
+    selectFormat,
+    activeFormat,
+    sessionActive,
+    startSession,
+    endSession,
+    currentQuestion,
+    isRecording,
+    elapsedSeconds,
+    toggleRecording,
+    nextQuestion,
+    skipQuestion,
+    isLoading,
+  };
+}

--- a/frontend/src/hooks/usePractice.ts
+++ b/frontend/src/hooks/usePractice.ts
@@ -1,0 +1,117 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+export interface CurrentQuestion {
+  label: string;
+  text: string;
+  questionNumber: number;
+  totalQuestions: number;
+}
+
+export interface ScorecardData {
+  substance: number;
+  structure: number;
+  relevance: number;
+  credibility: number;
+  differentiation: number;
+  hireSignal: string;
+  feedback: string;
+}
+
+const DRILL_STAGES = [
+  'Ladder',
+  'Pushback',
+  'Pivot',
+  'Gap',
+  'Role',
+  'Panel',
+  'Stress',
+  'Technical',
+];
+
+const DEFAULT_QUESTION: CurrentQuestion = {
+  label: 'Question 1 of 3 — Leadership',
+  text: 'Tell me about a time you had to rebuild a team during a period of significant organizational change.',
+  questionNumber: 1,
+  totalQuestions: 3,
+};
+
+const MOCK_SCORECARD: ScorecardData = {
+  substance: 4.3,
+  structure: 4.0,
+  relevance: 4.5,
+  credibility: 4.2,
+  differentiation: 3.5,
+  hireSignal: 'Strong Hire',
+  feedback:
+    'Excellent use of specific metrics and a clear STAR structure. The story demonstrated genuine leadership under pressure. Consider adding more about the long-term impact of the team rebuild to strengthen differentiation.',
+};
+
+export function usePractice() {
+  const [currentStage, setCurrentStage] = useState(1);
+  const [currentQuestion, setCurrentQuestion] = useState<CurrentQuestion>(DEFAULT_QUESTION);
+  const [isRecording, setIsRecording] = useState(false);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [scorecard, setScorecard] = useState<ScorecardData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Timer: start/stop based on isRecording
+  useEffect(() => {
+    if (isRecording) {
+      intervalRef.current = setInterval(() => {
+        setElapsedSeconds((prev) => prev + 1);
+      }, 1000);
+    } else if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [isRecording]);
+
+  const toggleRecording = useCallback(() => {
+    setIsRecording((prev) => !prev);
+  }, []);
+
+  const skipQuestion = useCallback(() => {
+    setIsRecording(false);
+    setElapsedSeconds(0);
+    setCurrentQuestion((prev) => {
+      const next = prev.questionNumber + 1;
+      if (next > prev.totalQuestions) {
+        return prev; // stay on last question
+      }
+      return {
+        ...prev,
+        label: `Question ${next} of ${prev.totalQuestions} — Leadership`,
+        questionNumber: next,
+      };
+    });
+  }, []);
+
+  const submitAnswer = useCallback(() => {
+    setIsRecording(false);
+    setIsLoading(true);
+    // Simulate API call delay
+    setTimeout(() => {
+      setScorecard(MOCK_SCORECARD);
+      setIsLoading(false);
+    }, 1200);
+  }, []);
+
+  return {
+    drillStages: DRILL_STAGES,
+    currentStage,
+    currentQuestion,
+    isRecording,
+    elapsedSeconds,
+    toggleRecording,
+    skipQuestion,
+    submitAnswer,
+    scorecard,
+    isLoading,
+  };
+}

--- a/frontend/src/hooks/usePrep.ts
+++ b/frontend/src/hooks/usePrep.ts
@@ -1,0 +1,148 @@
+import { useState } from 'react';
+import { useWorkspace } from '../contexts/WorkspaceContext';
+
+/* ── Type definitions ── */
+
+export interface CompanyOverview {
+  description: string;
+  cultureSignals: string[];
+  interviewProcess: string[];
+}
+
+export interface FitAssessment {
+  verdict: string;
+  confidence: string;
+  fitSignals: string[];
+  structuralGaps: { severity: string; text: string }[];
+}
+
+export interface Competency {
+  rank: number;
+  name: string;
+  description: string;
+}
+
+export interface StoryCoverage {
+  status: 'covered' | 'gap';
+  competency: string;
+  story: string;
+}
+
+export interface JdAnalysis {
+  competencies: Competency[];
+  storyCoverage: StoryCoverage[];
+}
+
+export interface Concern {
+  severity: 'high' | 'med' | 'low';
+  title: string;
+  counter: string;
+}
+
+export type PrepTab = 'research' | 'decode' | 'brief' | 'concerns' | 'questions' | 'present';
+
+/* ── Mock data matching the reference HTML (Google workspace) ── */
+
+const mockCompanyOverview: CompanyOverview = {
+  description:
+    "Google's AI/ML division is undergoing rapid expansion. The Director of Engineering role reports to a VP and owns a 50-80 person org building foundational ML infrastructure.",
+  cultureSignals: [
+    'Data-driven decision making is non-negotiable',
+    'Strong IC culture — Directors must stay technical',
+    'Consensus-oriented but expects leaders to drive alignment',
+  ],
+  interviewProcess: [
+    'R1: Behavioral screen (recruiter, 45 min)',
+    'R2: System design (HM, 60 min)',
+    'R3: Bar raiser / leadership deep-dive',
+    'R4: Team match',
+  ],
+};
+
+const mockFitAssessment: FitAssessment = {
+  verdict: 'Strong Fit',
+  confidence: 'High confidence',
+  fitSignals: [
+    'ML/AI platform leadership aligns directly with DoorDash voice AI work',
+    "Scale experience (1M+ calls/month) matches Google's infrastructure expectations",
+    'Berkeley MBA + technical depth = rare Director profile',
+  ],
+  structuralGaps: [
+    { severity: 'Frameable', text: 'No Google/FAANG pedigree — counter with scale metrics' },
+    { severity: 'Minor', text: 'Title gap (Sr. EM vs Director) — counter with scope evidence' },
+  ],
+};
+
+const mockJdAnalysis: JdAnalysis = {
+  competencies: [
+    { rank: 1, name: 'Technical Vision at Scale', description: 'designing ML systems for billions of queries' },
+    { rank: 2, name: 'Org Building', description: 'hiring and growing 50+ person engineering orgs' },
+    { rank: 3, name: 'Cross-functional Leadership', description: 'partnering with PM, Research, and Infra' },
+    { rank: 4, name: 'Execution Under Ambiguity', description: 'shipping in fast-moving AI landscape' },
+    { rank: 5, name: 'Stakeholder Management', description: 'VP-level communication and influence' },
+  ],
+  storyCoverage: [
+    { status: 'covered', competency: 'Technical Vision', story: 'S002 (Voice AI Platform)' },
+    { status: 'covered', competency: 'Org Building', story: 'S001 (Scaling 8 to 27)' },
+    { status: 'covered', competency: 'Cross-functional', story: 'S003 ($200M Marketplace)' },
+    { status: 'covered', competency: 'Execution', story: 'S004 (LLM Solutions)' },
+    { status: 'gap', competency: 'Stakeholder Management', story: 'need a dedicated story' },
+  ],
+};
+
+const mockConcerns: Concern[] = [
+  {
+    severity: 'high',
+    title: 'Title Gap:',
+    counter:
+      'Sr. EM seeking Director. Counter: "I\'ve been operating at Director scope for 2+ years — 35 person org, 3 managers, P&L ownership."',
+  },
+  {
+    severity: 'med',
+    title: 'No FAANG:',
+    counter:
+      'Lyft/DoorDash vs Google. Counter: "I\'ve built systems at comparable scale — 1M+ daily calls, $200M revenue platform."',
+  },
+  {
+    severity: 'low',
+    title: 'Short DoorDash tenure:',
+    counter:
+      '~10 months. Counter: "Deliberate scope expansion — took broader role to prove Director readiness."',
+  },
+];
+
+const mockQuestionsToAsk: string[] = [
+  '"What does success look like for this role in the first 6 months — and what\'s the biggest risk you see in getting there?"',
+  '"How does the team balance foundational ML infrastructure work with product-facing feature development?"',
+  '"What\'s the biggest technical bet the org is making right now, and how is that decision being made?"',
+  '"How much latitude does a Director have to reshape team structure and hiring priorities?"',
+  '"What happened to the last person in this role — or is this a new position?"',
+];
+
+/* ── Hook ── */
+
+export function usePrep() {
+  const { activeWorkspace } = useWorkspace();
+  const [activeTab, setActiveTab] = useState<PrepTab>('research');
+
+  // In a real app this would fetch from the API based on activeWorkspace.
+  // For now return mock data (Google workspace).
+  const isLoading = false;
+
+  return {
+    companyOverview: mockCompanyOverview,
+    fitAssessment: mockFitAssessment,
+    jdAnalysis: mockJdAnalysis,
+    concerns: mockConcerns,
+    questionsToAsk: mockQuestionsToAsk,
+    prepBrief: null as null,
+    presentation: null as null,
+    activeTab,
+    setActiveTab,
+    isLoading,
+    /** Convenience: the company/role string for the subtitle */
+    subtitle: activeWorkspace
+      ? `${activeWorkspace.company_name} — ${activeWorkspace.role_title}`
+      : 'Google — Director of Engineering, AI/ML',
+  };
+}

--- a/frontend/src/hooks/useProgress.ts
+++ b/frontend/src/hooks/useProgress.ts
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+/* ── Type definitions ── */
+
+export interface ScoreHistoryPoint {
+  substance: number;
+  structure: number;
+  relevance: number;
+  credibility: number;
+  differentiation: number;
+}
+
+export interface Calibration {
+  tendency: string;
+  delta: number;
+  latestScores: {
+    substance: number;
+    structure: number;
+    relevance: number;
+    credibility: number;
+    differentiation: number;
+  };
+}
+
+export interface PatternItem {
+  detected: string;
+  text: string;
+}
+
+export interface ProgressData {
+  scoreHistory: ScoreHistoryPoint[];
+  calibration: Calibration;
+  effectivePatterns: PatternItem[];
+  ineffectivePatterns: PatternItem[];
+}
+
+/* ── Mock data matching the reference HTML ── */
+
+const mockData: ProgressData = {
+  scoreHistory: [
+    { substance: 3.0, structure: 2.5, relevance: 3.5, credibility: 3.0, differentiation: 2.0 },
+    { substance: 3.3, structure: 3.0, relevance: 3.6, credibility: 3.2, differentiation: 2.3 },
+    { substance: 3.6, structure: 3.2, relevance: 4.0, credibility: 3.5, differentiation: 2.5 },
+    { substance: 3.8, structure: 3.5, relevance: 4.0, credibility: 3.7, differentiation: 3.0 },
+    { substance: 4.1, structure: 3.8, relevance: 4.2, credibility: 4.0, differentiation: 3.2 },
+    { substance: 4.3, structure: 4.0, relevance: 4.5, credibility: 4.2, differentiation: 3.5 },
+  ],
+
+  calibration: {
+    tendency: 'Over-rater',
+    delta: 0.8,
+    latestScores: {
+      substance: 4.3,
+      structure: 4.0,
+      relevance: 4.5,
+      credibility: 4.2,
+      differentiation: 3.5,
+    },
+  },
+
+  effectivePatterns: [
+    {
+      detected: 'across 4 sessions',
+      text: 'Leading with counterintuitive choices in prioritization stories consistently scores 4+ on Differentiation.',
+    },
+    {
+      detected: 'across 3 sessions',
+      text: 'Opening with a specific metric (\u201C1M calls/month\u201D) immediately anchors Credibility at 4+.',
+    },
+  ],
+
+  ineffectivePatterns: [
+    {
+      detected: 'across 3 uses',
+      text: 'Generic \u201CI aligned stakeholders\u201D language without naming the actual tension consistently scores below 3 on Differentiation.',
+    },
+    {
+      detected: 'across 2 sessions',
+      text: 'Answers exceeding 4 minutes lose Structure points \u2014 the narrative starts strong but meanders in the second half.',
+    },
+  ],
+};
+
+/* ── Hook ── */
+
+async function fetchProgress(): Promise<ProgressData> {
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  return mockData;
+}
+
+export function useProgress() {
+  const [activeFilter, setFilter] = useState<string>('all');
+
+  const query = useQuery({
+    queryKey: ['progress'],
+    queryFn: fetchProgress,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return {
+    scoreHistory: query.data?.scoreHistory ?? [],
+    calibration: query.data?.calibration ?? null,
+    effectivePatterns: query.data?.effectivePatterns ?? [],
+    ineffectivePatterns: query.data?.ineffectivePatterns ?? [],
+    activeFilter,
+    setFilter,
+    isLoading: query.isLoading,
+  };
+}

--- a/frontend/src/hooks/useStories.ts
+++ b/frontend/src/hooks/useStories.ts
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+
+export interface Story {
+  id: string;
+  title: string;
+  primarySkill: string;
+  secondarySkill: string;
+  earnedSecret: string;
+  strength: number; // 1-5
+  uses: number;
+  status: 'improve' | 'view';
+}
+
+export interface Gap {
+  severity: 'missing' | 'weak';
+  description: string;
+}
+
+const MOCK_STORIES: Story[] = [
+  {
+    id: 'S001',
+    title: 'Scaling Eng Org 8 to 27 Post-Layoffs',
+    primarySkill: 'Team Building',
+    secondarySkill: 'Change Mgmt',
+    earnedSecret: 'Hiring during crisis builds loyalty',
+    strength: 4,
+    uses: 3,
+    status: 'improve',
+  },
+  {
+    id: 'S002',
+    title: 'Voice AI Platform — 1M+ Calls/Month',
+    primarySkill: 'Technical Vision',
+    secondarySkill: 'Strategic Thinking',
+    earnedSecret: 'Build vs buy flips at scale',
+    strength: 5,
+    uses: 5,
+    status: 'view',
+  },
+  {
+    id: 'S003',
+    title: '$200M Marketplace Platform',
+    primarySkill: 'Business Impact',
+    secondarySkill: 'Cross-functional',
+    earnedSecret: 'Finance data as competitive moat',
+    strength: 4,
+    uses: 2,
+    status: 'improve',
+  },
+  {
+    id: 'S004',
+    title: 'LLM Solutions Saving $10M+',
+    primarySkill: 'Innovation',
+    secondarySkill: 'Cost Optimization',
+    earnedSecret: 'LLM ROI requires infra, not models',
+    strength: 4,
+    uses: 1,
+    status: 'improve',
+  },
+];
+
+const MOCK_GAPS: Gap[] = [
+  { severity: 'missing', description: 'Failure / learning story (critical for Director)' },
+  { severity: 'missing', description: 'Conflict resolution story' },
+  { severity: 'weak', description: 'Stakeholder management (S003 partially covers)' },
+];
+
+const NARRATIVE_IDENTITY =
+  'Builder who scales through ambiguity. Takes broken/nascent systems and builds them into platforms. Each story shows progressively larger scope \u2014 from infra ($5M) to org (27 engineers) to business ($200M) to company strategy (voice AI).';
+
+export function useStories() {
+  const [stories, setStories] = useState<Story[]>(MOCK_STORIES);
+  const [isLoading] = useState(false);
+
+  const gaps: Gap[] = MOCK_GAPS;
+  const narrativeIdentity: string = NARRATIVE_IDENTITY;
+
+  const addStory = (_story: Partial<Story>) => {
+    // No-op for now — will integrate with backend later
+    setStories((prev) => prev);
+  };
+
+  return { stories, gaps, narrativeIdentity, addStory, isLoading };
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,16 +1,264 @@
 import { useWorkspace } from '../contexts/WorkspaceContext';
+import { useDashboard } from '../hooks/useDashboard';
+import type { KanbanWorkspace, ScorePoint } from '../hooks/useDashboard';
+import './pages.css';
 
-export function Dashboard() {
-  const { isJobWorkspace, activeWorkspace } = useWorkspace();
+/* ── SVG Icon helpers (inline, no icon library) ── */
 
-  if (isJobWorkspace && activeWorkspace) {
+function IconGrid() {
+  return (
+    <svg className="icon" viewBox="0 0 18 18">
+      <rect x="2" y="2" width="5.5" height="5.5" rx="1" />
+      <rect x="10.5" y="2" width="5.5" height="5.5" rx="1" />
+      <rect x="2" y="10.5" width="5.5" height="5.5" rx="1" />
+      <rect x="10.5" y="10.5" width="5.5" height="5.5" rx="1" />
+    </svg>
+  );
+}
+
+function IconBook() {
+  return (
+    <svg className="icon" viewBox="0 0 18 18">
+      <path d="M2 3.5h5a2 2 0 0 1 2 2v10l-2.5-1.5L4 15.5v-10a2 2 0 0 0-2-2z" />
+      <path d="M16 3.5h-5a2 2 0 0 0-2 2v10l2.5-1.5L14 15.5v-10a2 2 0 0 1 2-2z" />
+    </svg>
+  );
+}
+
+function IconTrending() {
+  return (
+    <svg className="icon" viewBox="0 0 18 18">
+      <polyline points="2 14 6.5 9 10 11.5 16 4" />
+      <polyline points="12.5 4 16 4 16 7.5" />
+    </svg>
+  );
+}
+
+function IconCompass() {
+  return (
+    <svg className="icon" viewBox="0 0 18 18">
+      <circle cx="9" cy="9" r="7" />
+      <polygon points="11.5 6.5 7 7 6.5 11.5 11 11" />
+    </svg>
+  );
+}
+
+function IconTarget() {
+  return (
+    <svg className="icon" viewBox="0 0 18 18">
+      <circle cx="9" cy="9" r="7" />
+      <circle cx="9" cy="9" r="4" />
+      <circle cx="9" cy="9" r="1" />
+    </svg>
+  );
+}
+
+function IconBolt() {
+  return (
+    <svg className="icon" viewBox="0 0 18 18">
+      <polygon points="10 1 3 10 9 10 8 17 15 8 9 8" />
+    </svg>
+  );
+}
+
+function IconPlay() {
+  return (
+    <svg className="icon" viewBox="0 0 18 18">
+      <circle cx="9" cy="9" r="7" />
+      <polygon points="7.5 5.5 13 9 7.5 12.5" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+function IconClipboard() {
+  return (
+    <svg className="icon" viewBox="0 0 18 18">
+      <rect x="3" y="3" width="12" height="14" rx="1.5" />
+      <path d="M7 1h4v3H7z" />
+      <line x1="6" y1="8" x2="12" y2="8" />
+      <line x1="6" y1="11" x2="10" y2="11" />
+    </svg>
+  );
+}
+
+function IconCheck() {
+  return (
+    <svg viewBox="0 0 18 18">
+      <polyline points="4 9 7.5 12.5 14 5.5" />
+    </svg>
+  );
+}
+
+/* ── Strength dots ── */
+
+function StrengthBar({ value }: { value: number }) {
+  return (
+    <div className="strength-bar">
+      {[1, 2, 3, 4, 5].map((i) => (
+        <span key={i} className={`str-dot${i <= value ? ' filled' : ''}`} />
+      ))}
+    </div>
+  );
+}
+
+/* ── Score Chart (SVG) ── */
+
+function ScoreChart({ scores }: { scores: ScorePoint[] }) {
+  if (scores.length === 0) return null;
+
+  // Chart dimensions matching the reference: viewBox 0 0 380 180
+  const xStart = 30;
+  const xEnd = 370;
+  const yTop = 20;   // score = 5
+  const yBottom = 140; // score = 2
+
+  const xStep = scores.length > 1 ? (xEnd - xStart) / (scores.length - 1) : 0;
+
+  function scoreToY(score: number): number {
+    // Map score 2..5 to yBottom..yTop
+    return yBottom - ((score - 2) / 3) * (yBottom - yTop);
+  }
+
+  function makePoints(key: keyof Omit<ScorePoint, 'session'>): string {
+    return scores.map((s, i) => `${xStart + i * xStep},${scoreToY(s[key])}`).join(' ');
+  }
+
+  const dimensions: { key: keyof Omit<ScorePoint, 'session'>; color: string; label: string; dashed?: boolean }[] = [
+    { key: 'substance', color: 'var(--c-substance)', label: 'Sub' },
+    { key: 'structure', color: 'var(--c-structure)', label: 'Str' },
+    { key: 'relevance', color: 'var(--c-relevance)', label: 'Rel' },
+    { key: 'credibility', color: 'var(--c-credibility)', label: 'Cred' },
+    { key: 'differentiation', color: 'var(--c-differentiation)', label: 'Diff', dashed: true },
+  ];
+
+  const lastScore = scores[scores.length - 1];
+
+  return (
+    <>
+      <svg viewBox="0 0 380 180" style={{ width: '100%' }}>
+        {/* Grid lines */}
+        {[20, 60, 100, 140].map((y) => (
+          <line key={y} x1="25" y1={y} x2="370" y2={y} stroke="var(--border-light)" strokeWidth="0.5" />
+        ))}
+        {/* Y-axis labels */}
+        <text x="14" y="24" fontSize="9" fill="var(--text-muted)" textAnchor="end" fontFamily="var(--ff-body)">5</text>
+        <text x="14" y="64" fontSize="9" fill="var(--text-muted)" textAnchor="end" fontFamily="var(--ff-body)">4</text>
+        <text x="14" y="104" fontSize="9" fill="var(--text-muted)" textAnchor="end" fontFamily="var(--ff-body)">3</text>
+        <text x="14" y="144" fontSize="9" fill="var(--text-muted)" textAnchor="end" fontFamily="var(--ff-body)">2</text>
+
+        {/* Polylines for each dimension */}
+        {dimensions.map((dim) => (
+          <polyline
+            key={dim.key}
+            points={makePoints(dim.key)}
+            fill="none"
+            stroke={dim.color}
+            strokeWidth="2"
+            strokeDasharray={dim.dashed ? '4 3' : undefined}
+          />
+        ))}
+
+        {/* End-point circles */}
+        {dimensions.map((dim) => (
+          <circle
+            key={dim.key}
+            cx={xEnd}
+            cy={scoreToY(lastScore[dim.key])}
+            r="3"
+            fill={dim.color}
+          />
+        ))}
+      </svg>
+
+      <div className="chart-legend">
+        {dimensions.map((dim) => (
+          <span key={dim.key} className="chart-legend-item">
+            <span className="chart-legend-dot" style={{ background: dim.color }} />
+            {dim.label}
+          </span>
+        ))}
+      </div>
+    </>
+  );
+}
+
+/* ── Kanban Board ── */
+
+type KanbanStage = 'researched' | 'applied' | 'interviewing' | 'offer';
+
+const kanbanColumns: { stage: KanbanStage; label: string }[] = [
+  { stage: 'researched', label: 'Researched' },
+  { stage: 'applied', label: 'Applied' },
+  { stage: 'interviewing', label: 'Interviewing' },
+  { stage: 'offer', label: 'Offer' },
+];
+
+function KanbanBoard({ workspaces }: { workspaces: KanbanWorkspace[] }) {
+  return (
+    <div className="kanban">
+      {kanbanColumns.map((col) => {
+        const cards = workspaces.filter((ws) => ws.stage === col.stage);
+        return (
+          <div key={col.stage} className={`kc-${col.stage}`}>
+            <div className="kanban-col-header">
+              {col.label} <span className="cnt">{cards.length}</span>
+            </div>
+            {cards.length === 0 ? (
+              <div className="kanban-empty">None</div>
+            ) : (
+              cards.map((card) => (
+                <div key={card.company} className="k-card">
+                  <div className="k-card-co">{card.company}</div>
+                  <div className="k-card-role">{card.role}</div>
+                  <span
+                    className="k-card-tag"
+                    style={{ background: card.tagBg, color: card.tagColor }}
+                  >
+                    {card.status}
+                  </span>
+                </div>
+              ))
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/* ── Drill Stepper ── */
+
+function DrillStepper({ currentStage, stages }: { currentStage: number; stages: string[] }) {
+  return (
+    <div className="stepper">
+      {stages.map((label, i) => {
+        const stageNum = i + 1;
+        let className = 'step';
+        if (stageNum < currentStage) className += ' done';
+        else if (stageNum === currentStage) className += ' active';
+        return (
+          <div key={label} className={className}>
+            <div className="step-dot">{stageNum}</div>
+            <div className="step-label">{label}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/* ── General Dashboard View ── */
+
+function GeneralDashboard() {
+  const { profile, stories, scores, workspaces, drillProgression, coachingStrategy, isLoading } = useDashboard();
+
+  if (isLoading || !profile) {
     return (
       <div>
         <div className="page-header">
-          <h1 className="page-title">Dashboard</h1>
-          <p className="page-subtitle">{activeWorkspace.company_name} — {activeWorkspace.role_title}</p>
+          <h1 className="page-title"><IconGrid /> Dashboard</h1>
+          <p className="page-subtitle">Loading...</p>
         </div>
-        <p style={{ color: 'var(--text-muted)' }}>Job workspace dashboard — prep checklist, round timeline, filtered scores. (Task 13)</p>
       </div>
     );
   }
@@ -18,10 +266,271 @@ export function Dashboard() {
   return (
     <div>
       <div className="page-header">
-        <h1 className="page-title">Dashboard</h1>
-        <p className="page-subtitle">Welcome back. Here's your coaching overview.</p>
+        <h1 className="page-title"><IconGrid /> Dashboard</h1>
+        <p className="page-subtitle">Welcome back, {profile.name.split(' ')[0]}. Here's your coaching overview.</p>
       </div>
-      <p style={{ color: 'var(--text-muted)' }}>General dashboard — profile, storybank, scores, kanban, drill stepper. (Task 13)</p>
+
+      {/* Profile Card */}
+      <div className="card" style={{ marginBottom: 14 }}>
+        <div className="card-body">
+          <div className="profile-row">
+            <div className="profile-avatar">{profile.initials}</div>
+            <div>
+              <div className="profile-name">{profile.name}</div>
+              <div className="profile-role">{profile.role}</div>
+            </div>
+            <div className="profile-tags">
+              {profile.tags.map((tag) => (
+                <span key={tag.label} className={`tag ${tag.variant}`}>{tag.label}</span>
+              ))}
+            </div>
+          </div>
+          <div className="stat-row" style={{ marginTop: 12, paddingTop: 12, borderTop: '1px solid var(--border-light)' }}>
+            <div className="stat"><strong>Track:</strong> {profile.track}</div>
+            <div className="stat"><strong>Timeline:</strong> {profile.timeline}</div>
+            <div className="stat"><strong>Mode:</strong> {profile.mode}</div>
+            <div className="stat"><strong>Concern:</strong> {profile.concern}</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Storybank + Score Chart */}
+      <div className="card-grid card-grid-60-40" style={{ marginBottom: 14 }}>
+        {/* Storybank Summary */}
+        <div className="card">
+          <div className="card-header">
+            <span className="card-title"><IconBook /> Storybank</span>
+            <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>{stories.length} stories</span>
+          </div>
+          <div className="card-body" style={{ padding: 0 }}>
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Title</th>
+                  <th>Skill</th>
+                  <th>Strength</th>
+                  <th>Uses</th>
+                </tr>
+              </thead>
+              <tbody>
+                {stories.map((story) => (
+                  <tr key={story.id}>
+                    <td><span className="story-id">{story.id}</span></td>
+                    <td><span className="story-title">{story.title}</span></td>
+                    <td>{story.primarySkill}</td>
+                    <td><StrengthBar value={story.strength} /></td>
+                    <td>{story.uses}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Score History Chart */}
+        <div className="card">
+          <div className="card-header">
+            <span className="card-title"><IconTrending /> Score History</span>
+            <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>{scores.length} sessions</span>
+          </div>
+          <div className="card-body">
+            <ScoreChart scores={scores} />
+          </div>
+        </div>
+      </div>
+
+      {/* Kanban + Drill Progression */}
+      <div className="card-grid card-grid-60-40" style={{ marginBottom: 14 }}>
+        {/* Interview Loops Kanban */}
+        <div className="card">
+          <div className="card-header">
+            <span className="card-title"><IconCompass /> Interview Loops</span>
+            <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>{workspaces.length} active</span>
+          </div>
+          <div className="card-body">
+            <KanbanBoard workspaces={workspaces} />
+          </div>
+        </div>
+
+        {/* Drill Progression */}
+        <div className="card">
+          <div className="card-header">
+            <span className="card-title"><IconTarget /> Drill Progression</span>
+            <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+              Stage {drillProgression?.currentStage ?? 1}/{drillProgression?.stages.length ?? 8}
+            </span>
+          </div>
+          <div className="card-body">
+            {drillProgression && (
+              <DrillStepper
+                currentStage={drillProgression.currentStage}
+                stages={drillProgression.stages}
+              />
+            )}
+            {coachingStrategy && (
+              <div style={{ marginTop: 16, paddingTop: 14, borderTop: '1px solid var(--border-light)' }}>
+                <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)', marginBottom: 6 }}>
+                  Coaching Strategy
+                </div>
+                <div style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.7 }}>
+                  <strong style={{ color: 'var(--text)' }}>Bottleneck:</strong> {coachingStrategy.bottleneck}
+                  <br />
+                  <strong style={{ color: 'var(--text)' }}>Approach:</strong> {coachingStrategy.approach}
+                  <br />
+                  <strong style={{ color: 'var(--text)' }}>Calibration:</strong> {coachingStrategy.calibration}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Action Banner */}
+      <div className="action-banner">
+        <div className="action-icon">
+          <svg viewBox="0 0 18 18"><polygon points="10 1 3 10 9 10 8 17 15 8 9 8" /></svg>
+        </div>
+        <div className="action-text">
+          <div className="action-title">Build Your Storybank</div>
+          <div className="action-desc">You have 8 story seeds from your resume. Stories are the foundation for everything.</div>
+        </div>
+        <button className="btn btn-primary btn-sm">Start Stories</button>
+      </div>
     </div>
   );
+}
+
+/* ── Job Dashboard View ── */
+
+function JobDashboard() {
+  const { activeWorkspace } = useWorkspace();
+  const { jobDashboard, isLoading } = useDashboard();
+
+  if (isLoading || !jobDashboard) {
+    return (
+      <div>
+        <div className="page-header">
+          <h1 className="page-title"><IconGrid /> Dashboard</h1>
+          <p className="page-subtitle">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  const companyName = activeWorkspace?.company_name ?? jobDashboard.company;
+  const roleTitle = activeWorkspace?.role_title ?? jobDashboard.role;
+
+  return (
+    <div>
+      <div className="page-header">
+        <h1 className="page-title"><IconGrid /> Dashboard</h1>
+        <p className="page-subtitle">{companyName} — {roleTitle}</p>
+      </div>
+
+      {/* Job Header Card */}
+      <div className="card" style={{ marginBottom: 14 }}>
+        <div className="card-body">
+          <div className="job-header">
+            <div className="job-logo">{jobDashboard.logoInitial}</div>
+            <div className="job-info">
+              <div className="job-company">{companyName}</div>
+              <div className="job-role-title">{roleTitle}</div>
+            </div>
+            <div className="profile-tags">
+              <span className="tag tag-green">{jobDashboard.fit}</span>
+              <span className="tag tag-primary">{jobDashboard.status}</span>
+              <span className="tag tag-neutral">{jobDashboard.band}</span>
+            </div>
+          </div>
+          <div className="stat-row" style={{ marginTop: 12, paddingTop: 12, borderTop: '1px solid var(--border-light)' }}>
+            <div className="stat"><strong>Next Round:</strong> {jobDashboard.nextRound}</div>
+            <div className="stat"><strong>Fit Confidence:</strong> {jobDashboard.fitConfidence}</div>
+            <div className="stat"><strong>Stories Mapped:</strong> {jobDashboard.storiesMapped}</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Prep Checklist + Round Timeline */}
+      <div className="card-grid card-grid-2" style={{ marginBottom: 14 }}>
+        {/* Prep Checklist */}
+        <div className="card">
+          <div className="card-header">
+            <span className="card-title"><IconClipboard /> Prep Checklist</span>
+          </div>
+          <div className="card-body">
+            <ul className="checklist">
+              {jobDashboard.prepChecklist.map((item) => (
+                <li key={item.label}>
+                  {item.done ? (
+                    <span className="check-done"><IconCheck /></span>
+                  ) : (
+                    <span className="check-pending" />
+                  )}
+                  {item.label}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        {/* Round Timeline */}
+        <div className="card">
+          <div className="card-header">
+            <span className="card-title"><IconTrending /> Round Timeline</span>
+          </div>
+          <div className="card-body">
+            <ul className="round-timeline">
+              {jobDashboard.roundTimeline.map((round) => (
+                <li key={round.name} className="round-item">
+                  {round.status === 'completed' ? (
+                    <span className="round-dot completed">
+                      <svg style={{ width: 12, height: 12, stroke: 'white', strokeWidth: 2.5, fill: 'none' }} viewBox="0 0 18 18">
+                        <polyline points="4 9 7.5 12.5 14 5.5" />
+                      </svg>
+                    </span>
+                  ) : (
+                    <span className={`round-dot${round.status === 'upcoming' ? ' upcoming' : ''}`}>
+                      {round.number}
+                    </span>
+                  )}
+                  <div className="round-info">
+                    <div className="round-name">{round.name}</div>
+                    <div className="round-meta">{round.meta}</div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      {/* Action Banner */}
+      <div className="action-banner">
+        <div className="action-icon">
+          <svg viewBox="0 0 18 18">
+            <circle cx="9" cy="9" r="7" />
+            <polygon points="7.5 5.5 13 9 7.5 12.5" fill="currentColor" stroke="none" />
+          </svg>
+        </div>
+        <div className="action-text">
+          <div className="action-title">Run a Mock System Design</div>
+          <div className="action-desc">Your Round 2 is in 7 days. Practice communicating your design thinking with voice.</div>
+        </div>
+        <button className="btn btn-primary btn-sm">Start Mock</button>
+      </div>
+    </div>
+  );
+}
+
+/* ── Main export ── */
+
+export function Dashboard() {
+  const { isJobWorkspace } = useWorkspace();
+
+  if (isJobWorkspace) {
+    return <JobDashboard />;
+  }
+
+  return <GeneralDashboard />;
 }

--- a/frontend/src/pages/InterviewPrep.tsx
+++ b/frontend/src/pages/InterviewPrep.tsx
@@ -1,11 +1,318 @@
+import './pages.css';
+import { usePrep, type PrepTab } from '../hooks/usePrep';
+
+/* ── Inline SVG icons ── */
+
+function ClipboardIcon({ className = 'icon' }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24">
+      <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+      <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
+    </svg>
+  );
+}
+
+function ShieldIcon({ className = 'icon' }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24">
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+    </svg>
+  );
+}
+
+function HelpIcon({ className = 'icon' }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="10" />
+      <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  );
+}
+
+function MonitorIcon({ className = 'icon' }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24">
+      <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+      <line x1="8" y1="21" x2="16" y2="21" />
+      <line x1="12" y1="17" x2="12" y2="21" />
+    </svg>
+  );
+}
+
+/* ── Tab definitions ── */
+
+const tabs: { id: PrepTab; label: string }[] = [
+  { id: 'research', label: 'Research' },
+  { id: 'decode', label: 'Decode' },
+  { id: 'brief', label: 'Brief' },
+  { id: 'concerns', label: 'Concerns' },
+  { id: 'questions', label: 'Questions' },
+  { id: 'present', label: 'Present' },
+];
+
+/* ── Sub-components for each tab ── */
+
+function ResearchTab() {
+  const { companyOverview, fitAssessment } = usePrep();
+
+  return (
+    <div className="card-grid card-grid-2">
+      {/* Company Overview */}
+      <div className="card">
+        <div className="card-header">
+          <span className="card-title">Company Overview</span>
+        </div>
+        <div className="card-body prep-section">
+          <p>{companyOverview.description}</p>
+          <h3>Culture Signals</h3>
+          <ul className="prep-list">
+            {companyOverview.cultureSignals.map((signal, i) => (
+              <li key={i}>{signal}</li>
+            ))}
+          </ul>
+          <h3>Interview Process</h3>
+          <ul className="prep-list">
+            {companyOverview.interviewProcess.map((step, i) => (
+              <li key={i}>{step}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      {/* Fit Assessment */}
+      <div className="card">
+        <div className="card-header">
+          <span className="card-title">Fit Assessment</span>
+        </div>
+        <div className="card-body">
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
+            <span className="tag tag-green" style={{ fontSize: 13, padding: '6px 14px' }}>
+              {fitAssessment.verdict}
+            </span>
+            <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+              {fitAssessment.confidence}
+            </span>
+          </div>
+          <h3 style={{ fontSize: 13, fontWeight: 700, marginBottom: 8 }}>Fit Signals</h3>
+          <ul className="prep-list">
+            {fitAssessment.fitSignals.map((signal, i) => (
+              <li key={i}>{signal}</li>
+            ))}
+          </ul>
+          <h3 style={{ fontSize: 13, fontWeight: 700, marginBottom: 8, marginTop: 12 }}>
+            Structural Gaps
+          </h3>
+          <ul className="prep-list">
+            {fitAssessment.structuralGaps.map((gap, i) => (
+              <li key={i}>
+                <span
+                  className={`tag ${gap.severity === 'Frameable' ? 'tag-amber' : 'tag-neutral'}`}
+                  style={{ fontSize: 10 }}
+                >
+                  {gap.severity}
+                </span>{' '}
+                {gap.text}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DecodeTab() {
+  const { jdAnalysis } = usePrep();
+
+  return (
+    <div className="card">
+      <div className="card-header">
+        <span className="card-title">JD Analysis</span>
+      </div>
+      <div className="card-body prep-section">
+        <h3>Top 5 Competencies (Priority Order)</h3>
+        <ul className="prep-list">
+          {jdAnalysis.competencies.map((c) => (
+            <li key={c.rank}>
+              <strong>
+                {c.rank}. {c.name}
+              </strong>{' '}
+              — {c.description}
+            </li>
+          ))}
+        </ul>
+        <h3>Story Coverage</h3>
+        <ul className="prep-list">
+          {jdAnalysis.storyCoverage.map((sc, i) => (
+            <li key={i}>
+              <span
+                className={`tag ${sc.status === 'covered' ? 'tag-green' : 'tag-red'}`}
+                style={{ fontSize: 10 }}
+              >
+                {sc.status === 'covered' ? 'Covered' : 'Gap'}
+              </span>{' '}
+              {sc.competency} — {sc.story}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function BriefTab() {
+  return (
+    <div className="card">
+      <div className="card-body">
+        <div className="empty-state">
+          <div className="empty-state-icon">
+            <ClipboardIcon />
+          </div>
+          <div className="empty-state-title">Prep Brief</div>
+          <div className="empty-state-desc">
+            Full prep brief with day-of cheat sheet, predicted questions, and story mapping.
+          </div>
+          <button className="btn btn-primary" style={{ marginTop: 12 }}>
+            Generate Prep Brief
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ConcernsTab() {
+  const { concerns } = usePrep();
+
+  const severityClass: Record<string, string> = {
+    high: 'tag-red',
+    med: 'tag-amber',
+    low: 'tag-neutral',
+  };
+
+  const severityLabel: Record<string, string> = {
+    high: 'High',
+    med: 'Med',
+    low: 'Low',
+  };
+
+  return (
+    <div className="card">
+      <div className="card-header">
+        <span className="card-title">
+          <ShieldIcon /> Anticipated Concerns
+        </span>
+      </div>
+      <div className="card-body">
+        <ul className="prep-list">
+          {concerns.map((c, i) => (
+            <li key={i}>
+              <span className={`concern-severity ${severityClass[c.severity]}`}>
+                {severityLabel[c.severity]}
+              </span>{' '}
+              <span>
+                <strong>{c.title}</strong> {c.counter}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function QuestionsTab() {
+  const { questionsToAsk } = usePrep();
+
+  return (
+    <div className="card">
+      <div className="card-header">
+        <span className="card-title">
+          <HelpIcon /> Questions to Ask
+        </span>
+      </div>
+      <div className="card-body">
+        <ul className="prep-list">
+          {questionsToAsk.map((q, i) => (
+            <li key={i}>
+              <strong>{i + 1}.</strong> {q}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function PresentTab() {
+  return (
+    <div className="card">
+      <div className="card-body">
+        <div className="empty-state">
+          <div className="empty-state-icon">
+            <MonitorIcon />
+          </div>
+          <div className="empty-state-title">No Presentation Round</div>
+          <div className="empty-state-desc">
+            This interview loop doesn't include a presentation round. If one is added, prep tools
+            will appear here.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Main page component ── */
+
 export function InterviewPrep() {
+  const { activeTab, setActiveTab, subtitle, isLoading } = usePrep();
+
+  if (isLoading) {
+    return (
+      <div>
+        <div className="page-header">
+          <h1 className="page-title">
+            <ClipboardIcon /> Interview Prep
+          </h1>
+          <p className="page-subtitle">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  const tabContent: Record<PrepTab, JSX.Element> = {
+    research: <ResearchTab />,
+    decode: <DecodeTab />,
+    brief: <BriefTab />,
+    concerns: <ConcernsTab />,
+    questions: <QuestionsTab />,
+    present: <PresentTab />,
+  };
+
   return (
     <div>
       <div className="page-header">
-        <h1 className="page-title">Interview Prep</h1>
-        <p className="page-subtitle">Company research, JD decode, prep brief, concerns, questions.</p>
+        <h1 className="page-title">
+          <ClipboardIcon /> Interview Prep
+        </h1>
+        <p className="page-subtitle">{subtitle}</p>
       </div>
-      <p style={{ color: 'var(--text-muted)' }}>Tabbed view: Research | Decode | Brief | Concerns | Questions | Present. (Task 17)</p>
+
+      <div className="tabs">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            className={`tab${activeTab === tab.id ? ' active' : ''}`}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {tabContent[activeTab]}
     </div>
   );
 }

--- a/frontend/src/pages/Materials.tsx
+++ b/frontend/src/pages/Materials.tsx
@@ -1,11 +1,306 @@
+import { useSearchParams } from 'react-router-dom';
+import { useMaterials } from '../hooks/useMaterials';
+import type { MaterialTab } from '../hooks/useMaterials';
+import { ResumeUpload } from '../components/ResumeUpload';
+import './pages.css';
+
+/* ── Inline SVG icons ── */
+
+function DocIcon() {
+  return (
+    <svg
+      className="icon"
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M4.5 2h6.5l4 4v9.5a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 3 15.5v-12A1.5 1.5 0 0 1 4.5 2z" />
+      <polyline points="11 2 11 6 15 6" />
+      <line x1="6" y1="9.5" x2="12" y2="9.5" />
+      <line x1="6" y1="12.5" x2="10" y2="12.5" />
+    </svg>
+  );
+}
+
+function LinkIcon() {
+  return (
+    <svg
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ width: 24, height: 24 }}
+    >
+      <path d="M7.5 10.5a3.5 3.5 0 0 0 5 0l2-2a3.5 3.5 0 0 0-5-5l-1 1" />
+      <path d="M10.5 7.5a3.5 3.5 0 0 0-5 0l-2 2a3.5 3.5 0 0 0 5 5l1-1" />
+    </svg>
+  );
+}
+
+function SendIcon() {
+  return (
+    <svg
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ width: 24, height: 24 }}
+    >
+      <line x1="16" y1="2" x2="8" y2="10" />
+      <polygon points="16 2 11 16 8 10 2 7" />
+    </svg>
+  );
+}
+
+function DollarIcon() {
+  return (
+    <svg
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ width: 24, height: 24 }}
+    >
+      <line x1="9" y1="1" x2="9" y2="17" />
+      <path d="M13 5c-1-1.5-2.5-2-4-2s-4 .8-4 3c0 4.5 8 2 8 6.5 0 2-2 3-4 3s-3.5-1-4.5-2.5" />
+    </svg>
+  );
+}
+
+/* ── Tab definitions ── */
+
+const TABS: { key: MaterialTab; label: string }[] = [
+  { key: 'resume', label: 'Resume' },
+  { key: 'linkedin', label: 'LinkedIn' },
+  { key: 'pitch', label: 'Pitch' },
+  { key: 'outreach', label: 'Outreach' },
+  { key: 'salary', label: 'Salary' },
+];
+
+const VALID_TABS = new Set<string>(TABS.map((t) => t.key));
+
+function getInitialTab(searchParams: URLSearchParams): MaterialTab {
+  const tab = searchParams.get('tab');
+  if (tab && VALID_TABS.has(tab)) {
+    return tab as MaterialTab;
+  }
+  return 'resume';
+}
+
+/* ── Severity tag helper ── */
+
+function severityLabel(severity: 'red' | 'amber' | 'neutral') {
+  switch (severity) {
+    case 'red':
+      return 'Fix';
+    case 'amber':
+      return 'Improve';
+    case 'neutral':
+      return 'Nice';
+  }
+}
+
+/* ── Page component ── */
+
 export function Materials() {
+  const [searchParams] = useSearchParams();
+  const initialTab = getInitialTab(searchParams);
+  const { activeTab, setActiveTab, resume, pitch, isLoading } = useMaterials(initialTab);
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 40, color: 'var(--text-muted)' }}>Loading materials...</div>
+    );
+  }
+
   return (
     <div>
+      {/* ── Page header ── */}
       <div className="page-header">
-        <h1 className="page-title">Materials</h1>
-        <p className="page-subtitle">Resume, LinkedIn, pitch, outreach, and salary.</p>
+        <h1 className="page-title">
+          <DocIcon /> Materials
+        </h1>
+        <p className="page-subtitle">
+          Your application materials &mdash; resume, LinkedIn, pitch, and outreach.
+        </p>
       </div>
-      <p style={{ color: 'var(--text-muted)' }}>Tabbed view: Resume | LinkedIn | Pitch | Outreach | Salary. (Task 19)</p>
+
+      {/* ── Tabs ── */}
+      <div className="tabs">
+        {TABS.map((tab) => (
+          <button
+            key={tab.key}
+            className={`tab${activeTab === tab.key ? ' active' : ''}`}
+            onClick={() => setActiveTab(tab.key)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* ── Resume tab ── */}
+      {activeTab === 'resume' && (
+        <div className="card">
+          <div className="card-header">
+            <span className="card-title">Resume Optimization</span>
+            <ResumeUpload onUpload={(file) => console.log('Resume uploaded:', file.name)} />
+          </div>
+          <div className="card-body">
+            {/* Score section */}
+            <div className="material-score">
+              <div className="material-score-circle">{resume.grade}</div>
+              <div className="material-dims">
+                <div className="material-dim">
+                  <strong>ATS:</strong> {resume.dimensions.ats}
+                </div>
+                <div className="material-dim">
+                  <strong>Recruiter Scan:</strong> {resume.dimensions.recruiterScan}
+                </div>
+                <div className="material-dim">
+                  <strong>Bullet Quality:</strong> {resume.dimensions.bulletQuality}
+                </div>
+                <div className="material-dim">
+                  <strong>Seniority:</strong> {resume.dimensions.seniority}
+                </div>
+                <div className="material-dim">
+                  <strong>Keywords:</strong> {resume.dimensions.keywords}
+                </div>
+              </div>
+            </div>
+
+            {/* Top Fixes */}
+            <h3 style={{ fontSize: 13, fontWeight: 700, marginBottom: 8 }}>Top Fixes</h3>
+            <ul className="prep-list">
+              {resume.topFixes.map((fix, i) => (
+                <li key={i}>
+                  <span
+                    className={`tag tag-${fix.severity}`}
+                    style={{ fontSize: 10 }}
+                  >
+                    {severityLabel(fix.severity)}
+                  </span>
+                  {fix.text}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+
+      {/* ── LinkedIn tab ── */}
+      {activeTab === 'linkedin' && (
+        <div className="card">
+          <div className="card-body">
+            <div className="empty-state">
+              <div className="empty-state-icon">
+                <LinkIcon />
+              </div>
+              <div className="empty-state-title">LinkedIn Audit</div>
+              <div className="empty-state-desc">
+                Paste your LinkedIn profile URL to get a section-by-section optimization audit.
+              </div>
+              <button className="btn btn-primary" style={{ marginTop: 12 }}>
+                Start Audit
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── Pitch tab ── */}
+      {activeTab === 'pitch' && (
+        <div className="card">
+          <div className="card-header">
+            <span className="card-title">Positioning Statement</span>
+          </div>
+          <div className="card-body prep-section">
+            <div
+              style={{
+                fontSize: 12,
+                fontWeight: 700,
+                color: 'var(--text-muted)',
+                textTransform: 'uppercase',
+                marginBottom: 4,
+              }}
+            >
+              10-Second Hook
+            </div>
+            <p
+              style={{
+                fontFamily: 'var(--ff-display)',
+                fontSize: 18,
+                lineHeight: 1.5,
+                marginBottom: 16,
+              }}
+            >
+              {pitch.hook10s}
+            </p>
+            <div
+              style={{
+                fontSize: 12,
+                fontWeight: 700,
+                color: 'var(--text-muted)',
+                textTransform: 'uppercase',
+                marginBottom: 4,
+              }}
+            >
+              Full Statement (30s)
+            </div>
+            <p>{pitch.fullStatement}</p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Outreach tab ── */}
+      {activeTab === 'outreach' && (
+        <div className="card">
+          <div className="card-body">
+            <div className="empty-state">
+              <div className="empty-state-icon">
+                <SendIcon />
+              </div>
+              <div className="empty-state-title">Outreach Coaching</div>
+              <div className="empty-state-desc">
+                Get help crafting cold outreach, warm intros, informational interview asks, and
+                recruiter replies.
+              </div>
+              <button className="btn btn-primary" style={{ marginTop: 12 }}>
+                Start Coaching
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── Salary tab ── */}
+      {activeTab === 'salary' && (
+        <div className="card">
+          <div className="card-body">
+            <div className="empty-state">
+              <div className="empty-state-icon">
+                <DollarIcon />
+              </div>
+              <div className="empty-state-title">Comp Strategy</div>
+              <div className="empty-state-desc">
+                Prepare for salary questions before they come up. Get scripts, range research, and
+                negotiation frameworks.
+              </div>
+              <button className="btn btn-primary" style={{ marginTop: 12 }}>
+                Build Strategy
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/MockInterview.tsx
+++ b/frontend/src/pages/MockInterview.tsx
@@ -1,11 +1,134 @@
+import './pages.css';
+import { useMock } from '../hooks/useMock';
+import { MockSession } from '../components/MockSession';
+import { useState } from 'react';
+
 export function MockInterview() {
+  const {
+    formats,
+    selectedFormat,
+    selectFormat,
+    activeFormat,
+    sessionActive,
+    startSession,
+    endSession,
+    currentQuestion,
+    isRecording,
+    elapsedSeconds,
+    toggleRecording,
+    nextQuestion,
+    skipQuestion,
+  } = useMock();
+
+  const [hoveredCard, setHoveredCard] = useState<string | null>(null);
+
+  // Select a format and immediately start the session
+  const handleSelectFormat = (id: string) => {
+    selectFormat(id);
+    // startSession runs on next tick so selectedFormat state is set first
+    setTimeout(() => startSession(), 0);
+  };
+
+  // Session active view
+  if (sessionActive && activeFormat && currentQuestion) {
+    return (
+      <div>
+        <div className="page-header">
+          <h1 className="page-title">
+            <svg
+              className="icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <polygon points="10,8 16,12 10,16" fill="currentColor" stroke="none" />
+            </svg>
+            Mock Interview
+          </h1>
+          <p className="page-subtitle">
+            {activeFormat.name} — Question {currentQuestion.questionNumber} of{' '}
+            {currentQuestion.totalQuestions}
+          </p>
+        </div>
+
+        <MockSession
+          format={activeFormat}
+          currentQuestion={currentQuestion}
+          isRecording={isRecording}
+          elapsedSeconds={elapsedSeconds}
+          onToggleRecording={toggleRecording}
+          onSkip={skipQuestion}
+          onNext={nextQuestion}
+          onEnd={endSession}
+        />
+      </div>
+    );
+  }
+
+  // Format selector view
   return (
     <div>
       <div className="page-header">
-        <h1 className="page-title">Mock Interview</h1>
-        <p className="page-subtitle">Full simulated interview with voice.</p>
+        <h1 className="page-title">
+          <svg
+            className="icon"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <polygon points="10,8 16,12 10,16" fill="currentColor" stroke="none" />
+          </svg>
+          Mock Interview
+        </h1>
+        <p className="page-subtitle">
+          Full simulated interview with voice. Choose a format to begin.
+        </p>
       </div>
-      <p style={{ color: 'var(--text-muted)' }}>Format selector, voice interview flow, post-mock feedback. (Task 16)</p>
+
+      <div className="card-grid card-grid-3" style={{ marginBottom: 14 }}>
+        {formats.map((format) => (
+          <div
+            key={format.id}
+            className="card"
+            style={{
+              cursor: 'pointer',
+              transition: 'border-color 0.15s',
+              borderColor:
+                hoveredCard === format.id
+                  ? 'var(--primary)'
+                  : 'var(--border-light)',
+            }}
+            onMouseEnter={() => setHoveredCard(format.id)}
+            onMouseLeave={() => setHoveredCard(null)}
+            onClick={() => handleSelectFormat(format.id)}
+          >
+            <div
+              className="card-body"
+              style={{ textAlign: 'center', padding: 24 }}
+            >
+              <div style={{ fontSize: 28, marginBottom: 8 }}>
+                {format.emoji}
+              </div>
+              <div
+                style={{ fontSize: 14, fontWeight: 700, marginBottom: 4 }}
+              >
+                {format.name}
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--text-muted)', whiteSpace: 'pre-line' }}>
+                {format.description}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/Practice.tsx
+++ b/frontend/src/pages/Practice.tsx
@@ -1,11 +1,120 @@
+import './pages.css';
+import { usePractice } from '../hooks/usePractice';
+import { VoiceRecorder } from '../components/VoiceRecorder';
+import { Scorecard } from '../components/Scorecard';
+
 export function Practice() {
+  const {
+    drillStages,
+    currentStage,
+    currentQuestion,
+    isRecording,
+    elapsedSeconds,
+    toggleRecording,
+    skipQuestion,
+    submitAnswer,
+    scorecard,
+    isLoading,
+  } = usePractice();
+
   return (
     <div>
+      {/* Page Header */}
       <div className="page-header">
-        <h1 className="page-title">Practice</h1>
-        <p className="page-subtitle">8-stage drill system with 5-dimension scoring.</p>
+        <h1 className="page-title">
+          <svg className="icon" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="9" cy="9" r="7" />
+            <circle cx="9" cy="9" r="4" />
+            <circle cx="9" cy="9" r="1" />
+          </svg>
+          Practice
+        </h1>
+        <p className="page-subtitle">
+          8-stage drill system with 5-dimension scoring and interviewer perspective.
+        </p>
       </div>
-      <p style={{ color: 'var(--text-muted)' }}>Drill stepper, voice interface, question display, timer, scorecard. (Task 15)</p>
+
+      {/* Drill Progression Card */}
+      <div className="card" style={{ marginBottom: 14 }}>
+        <div className="card-header">
+          <span className="card-title">Drill Progression</span>
+        </div>
+        <div className="card-body">
+          <div className="stepper">
+            {drillStages.map((stage, idx) => {
+              const stepNum = idx + 1;
+              const isActive = stepNum === currentStage;
+              const isDone = stepNum < currentStage;
+              const className = `step${isActive ? ' active' : ''}${isDone ? ' done' : ''}`;
+              return (
+                <div className={className} key={stage}>
+                  <div className="step-dot">{stepNum}</div>
+                  <div className="step-label">{stage}</div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Practice Session Card */}
+      <div className="card">
+        <div className="card-header">
+          <span className="card-title">
+            <svg className="icon" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="6" y="1" width="6" height="10" rx="3" />
+              <path d="M3 8a6 6 0 0 0 12 0" />
+              <line x1="9" y1="14" x2="9" y2="17" />
+              <line x1="6" y1="17" x2="12" y2="17" />
+            </svg>
+            Practice Session
+          </span>
+        </div>
+        <div className="card-body">
+          {scorecard ? (
+            <Scorecard
+              scores={{
+                substance: scorecard.substance,
+                structure: scorecard.structure,
+                relevance: scorecard.relevance,
+                credibility: scorecard.credibility,
+                differentiation: scorecard.differentiation,
+              }}
+              hireSignal={scorecard.hireSignal}
+              feedback={scorecard.feedback}
+            />
+          ) : (
+            <div className="voice-area">
+              {/* Question Display */}
+              <div className="voice-question">
+                <div className="voice-question-label">{currentQuestion.label}</div>
+                <div className="voice-question-text">{currentQuestion.text}</div>
+              </div>
+
+              {/* Voice Recorder */}
+              <VoiceRecorder
+                isRecording={isRecording}
+                onToggle={toggleRecording}
+                elapsedSeconds={elapsedSeconds}
+              />
+
+              {/* Controls */}
+              <div className="voice-controls">
+                <button className="btn btn-outline btn-sm" onClick={skipQuestion}>
+                  Skip
+                </button>
+                <button
+                  className="btn btn-primary btn-sm"
+                  onClick={submitAnswer}
+                  disabled={isLoading}
+                >
+                  {isLoading ? 'Scoring...' : 'Submit Answer'}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/Progress.tsx
+++ b/frontend/src/pages/Progress.tsx
@@ -1,11 +1,159 @@
+import './pages.css';
+import { useProgress } from '../hooks/useProgress';
+import { ScoreTrendChart } from '../components/ScoreTrendChart';
+
+type DimensionKey = 'substance' | 'structure' | 'relevance' | 'credibility' | 'differentiation';
+
+const DIMENSIONS: { key: DimensionKey; label: string; color: string }[] = [
+  { key: 'substance', label: 'Substance', color: 'var(--c-substance)' },
+  { key: 'structure', label: 'Structure', color: 'var(--c-structure)' },
+  { key: 'relevance', label: 'Relevance', color: 'var(--c-relevance)' },
+  { key: 'credibility', label: 'Credibility', color: 'var(--c-credibility)' },
+  { key: 'differentiation', label: 'Differentiation', color: 'var(--c-differentiation)' },
+];
+
+/** Convert a score (1-5) to a percentage width for progress bars */
+function scoreToPercent(score: number): number {
+  return (score / 5) * 100;
+}
+
 export function Progress() {
+  const {
+    scoreHistory,
+    calibration,
+    effectivePatterns,
+    ineffectivePatterns,
+    activeFilter,
+    setFilter,
+    isLoading,
+  } = useProgress();
+
+  if (isLoading) {
+    return (
+      <div>
+        <div className="page-header">
+          <h1 className="page-title">Progress</h1>
+          <p className="page-subtitle">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div>
+      {/* Page header */}
       <div className="page-header">
-        <h1 className="page-title">Progress</h1>
-        <p className="page-subtitle">Score trends, self-calibration, and coaching patterns.</p>
+        <h1 className="page-title">
+          <svg className="icon" viewBox="0 0 18 18">
+            <polyline points="2 14 6.5 9 10 11.5 16 4" />
+            <polyline points="12.5 4 16 4 16 7.5" />
+          </svg>
+          {' '}Progress
+        </h1>
+        <p className="page-subtitle">Score trends, self-calibration, patterns, and coaching strategy.</p>
       </div>
-      <p style={{ color: 'var(--text-muted)' }}>Score chart, calibration display, effective/ineffective patterns. (Task 18)</p>
+
+      {/* Top row: 60/40 grid */}
+      <div className="card-grid card-grid-60-40" style={{ marginBottom: 14 }}>
+        {/* Score Trends card */}
+        <div className="card">
+          <ScoreTrendChart
+            data={scoreHistory}
+            filter={activeFilter}
+            onFilterChange={setFilter}
+          />
+        </div>
+
+        {/* Self-Calibration card */}
+        <div className="card">
+          <div className="card-header">
+            <span className="card-title">Self-Calibration</span>
+          </div>
+          <div className="card-body">
+            {calibration && (
+              <>
+                <div style={{ textAlign: 'center', marginBottom: 16 }}>
+                  <div
+                    style={{
+                      fontSize: 32,
+                      fontWeight: 700,
+                      color: 'var(--c-differentiation)',
+                    }}
+                  >
+                    {calibration.tendency}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 12,
+                      color: 'var(--text-muted)',
+                      marginTop: 4,
+                    }}
+                  >
+                    Your self-scores average {calibration.delta} points above coach scores
+                  </div>
+                </div>
+                <div className="score-dims">
+                  {DIMENSIONS.map((dim) => {
+                    const score = calibration.latestScores[dim.key];
+                    return (
+                      <div className="score-dim" key={dim.key}>
+                        <span className="score-dim-label">{dim.label}</span>
+                        <div className="score-dim-bar">
+                          <div
+                            className="score-dim-fill"
+                            style={{
+                              width: `${scoreToPercent(score)}%`,
+                              background: dim.color,
+                            }}
+                          />
+                        </div>
+                        <span className="score-dim-val">{score.toFixed(1)}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom row: 50/50 grid */}
+      <div className="card-grid card-grid-2">
+        {/* Effective Patterns */}
+        <div className="card">
+          <div className="card-header">
+            <span className="card-title" style={{ color: '#2eaa4a' }}>
+              Effective Patterns
+            </span>
+          </div>
+          <div className="card-body">
+            {effectivePatterns.map((pattern, i) => (
+              <div className="pattern-item" key={i}>
+                <div className="pattern-label">Detected {pattern.detected}</div>
+                <div className="pattern-text">{pattern.text}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Ineffective Patterns */}
+        <div className="card">
+          <div className="card-header">
+            <span className="card-title" style={{ color: 'var(--c-credibility)' }}>
+              Ineffective Patterns
+            </span>
+          </div>
+          <div className="card-body">
+            {ineffectivePatterns.map((pattern, i) => (
+              <div className="pattern-item" key={i}>
+                <div className="pattern-label">Detected {pattern.detected}</div>
+                <div className="pattern-text">{pattern.text}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/Storybank.tsx
+++ b/frontend/src/pages/Storybank.tsx
@@ -1,11 +1,249 @@
+import { useState } from 'react';
+import { useStories } from '../hooks/useStories';
+import { StoryForm } from '../components/StoryForm';
+import './pages.css';
+
+/* ── Inline SVG icons (from reference HTML symbol defs) ── */
+
+function BookIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="icon"
+    >
+      <path d="M2 3.5h5a2 2 0 0 1 2 2v10l-2.5-1.5L4 15.5v-10a2 2 0 0 0-2-2z" />
+      <path d="M16 3.5h-5a2 2 0 0 0-2 2v10l2.5-1.5L14 15.5v-10a2 2 0 0 1 2-2z" />
+    </svg>
+  );
+}
+
+function PlusIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="white"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="icon"
+      style={{ width: 14, height: 14 }}
+    >
+      <line x1="9" y1="3" x2="9" y2="15" />
+      <line x1="3" y1="9" x2="15" y2="9" />
+    </svg>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="icon"
+    >
+      <circle cx="7.5" cy="7.5" r="4.5" />
+      <line x1="11" y1="11" x2="15.5" y2="15.5" />
+    </svg>
+  );
+}
+
+function CompassIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="icon"
+    >
+      <circle cx="9" cy="9" r="7" />
+      <polygon points="11.5 6.5 7 7 6.5 11.5 11 11" />
+    </svg>
+  );
+}
+
+/* ── Strength dot bar ── */
+
+function StrengthBar({ value }: { value: number }) {
+  return (
+    <div className="strength-bar">
+      {[1, 2, 3, 4, 5].map((n) => (
+        <span key={n} className={`str-dot${n <= value ? ' filled' : ''}`} />
+      ))}
+    </div>
+  );
+}
+
+/* ── Page component ── */
+
 export function Storybank() {
+  const { stories, gaps, narrativeIdentity, addStory, isLoading } = useStories();
+  const [showForm, setShowForm] = useState(false);
+
+  const storyCount = stories.length;
+  const gapCount = gaps.length;
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 40, color: 'var(--text-muted)' }}>Loading stories...</div>
+    );
+  }
+
   return (
     <div>
-      <div className="page-header">
-        <h1 className="page-title">Storybank</h1>
-        <p className="page-subtitle">Your interview-ready STAR stories.</p>
+      {/* ── Header row ── */}
+      <div
+        className="page-header"
+        style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}
+      >
+        <div>
+          <h1 className="page-title">
+            <BookIcon /> Storybank
+          </h1>
+          <p className="page-subtitle">
+            Your interview-ready STAR stories. {storyCount} stories built, {gapCount} gaps
+            identified.
+          </p>
+        </div>
+        <button
+          className="btn btn-primary"
+          onClick={() => setShowForm((v) => !v)}
+        >
+          <PlusIcon /> Add Story
+        </button>
       </div>
-      <p style={{ color: 'var(--text-muted)' }}>Story table, add/improve, gap analysis, narrative identity. (Task 14)</p>
+
+      {/* ── Story form (toggled) ── */}
+      {showForm && (
+        <StoryForm
+          onSave={(data) => {
+            addStory({
+              title: data.title,
+              primarySkill: data.primarySkill,
+              secondarySkill: data.secondarySkill,
+              earnedSecret: data.earnedSecret,
+              strength: data.strength,
+            });
+            setShowForm(false);
+          }}
+          onCancel={() => setShowForm(false)}
+        />
+      )}
+
+      {/* ── Story table ── */}
+      <div className="card" style={{ marginBottom: 14 }}>
+        <div className="card-body" style={{ padding: 0 }}>
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Title</th>
+                <th>Primary Skill</th>
+                <th>Secondary Skill</th>
+                <th>Earned Secret</th>
+                <th>Strength</th>
+                <th>Uses</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {stories.map((s) => (
+                <tr key={s.id}>
+                  <td>
+                    <span className="story-id">{s.id}</span>
+                  </td>
+                  <td>
+                    <span className="story-title">{s.title}</span>
+                  </td>
+                  <td>{s.primarySkill}</td>
+                  <td>{s.secondarySkill}</td>
+                  <td>{s.earnedSecret}</td>
+                  <td>
+                    <StrengthBar value={s.strength} />
+                  </td>
+                  <td>{s.uses}</td>
+                  <td>
+                    <button className="btn btn-outline btn-sm">
+                      {s.status === 'view' ? 'View' : 'Improve'}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* ── Two-column grid: Gap Analysis + Narrative Identity ── */}
+      <div className="card-grid card-grid-2">
+        {/* Gap Analysis */}
+        <div className="card">
+          <div className="card-header">
+            <span className="card-title">
+              <SearchIcon /> Gap Analysis
+            </span>
+          </div>
+          <div className="card-body">
+            <div className="prep-list">
+              {gaps.map((gap, i) => (
+                <li key={i}>
+                  <span
+                    className={`tag ${gap.severity === 'missing' ? 'tag-red' : 'tag-amber'}`}
+                    style={{ fontSize: 10 }}
+                  >
+                    {gap.severity === 'missing' ? 'Missing' : 'Weak'}
+                  </span>{' '}
+                  {gap.description}
+                </li>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Narrative Identity */}
+        <div className="card">
+          <div className="card-header">
+            <span className="card-title">
+              <CompassIcon /> Narrative Identity
+            </span>
+          </div>
+          <div className="card-body">
+            <p
+              style={{
+                fontSize: 13,
+                color: 'var(--text-secondary)',
+                lineHeight: 1.7,
+              }}
+            >
+              <strong>Core themes:</strong> {narrativeIdentity}
+            </p>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/pages.css
+++ b/frontend/src/pages/pages.css
@@ -1,0 +1,213 @@
+/* ============ SHARED PAGE COMPONENTS ============ */
+
+/* Icon base */
+.icon { width: 18px; height: 18px; flex-shrink: 0; stroke: currentColor; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; fill: none; }
+
+/* Page header */
+.page-header { margin-bottom: 20px; }
+.page-title { font-family: var(--ff-display); font-size: 24px; display: flex; align-items: center; gap: 10px; }
+.page-title .icon { width: 22px; height: 22px; color: var(--primary); }
+.page-subtitle { font-size: 13px; color: var(--text-muted); margin-top: 2px; }
+
+/* Cards */
+.card { background: var(--card); border: 1px solid var(--border-light); border-radius: var(--radius-md); box-shadow: var(--shadow-xs); }
+.card-header { padding: 14px 18px; border-bottom: 1px solid var(--border-light); display: flex; align-items: center; justify-content: space-between; }
+.card-title { font-size: 13px; font-weight: 700; display: flex; align-items: center; gap: 8px; }
+.card-title .icon { width: 15px; height: 15px; color: var(--primary); }
+.card-body { padding: 18px; }
+.card-grid { display: grid; gap: 14px; }
+.card-grid-2 { grid-template-columns: 1fr 1fr; }
+.card-grid-3 { grid-template-columns: 1fr 1fr 1fr; }
+.card-grid-60-40 { grid-template-columns: 1.4fr 1fr; }
+
+/* Buttons */
+.btn { font-family: var(--ff-body); font-weight: 600; border: none; border-radius: var(--radius-sm); cursor: pointer; transition: all 0.15s; display: inline-flex; align-items: center; gap: 6px; }
+.btn-primary { background: var(--primary); color: var(--text-inverse); padding: 8px 18px; font-size: 13px; }
+.btn-primary:hover { background: var(--primary-dark); }
+.btn-outline { background: transparent; color: var(--primary-dark); border: 1px solid var(--border); padding: 7px 16px; font-size: 13px; }
+.btn-outline:hover { border-color: var(--primary); background: var(--primary-lighter); }
+.btn-sm { padding: 5px 12px; font-size: 12px; }
+
+/* Tags */
+.tag { font-size: 11px; font-weight: 600; padding: 3px 10px; border-radius: 100px; white-space: nowrap; display: inline-block; }
+.tag-primary { background: var(--primary-light); color: var(--primary-dark); }
+.tag-neutral { background: var(--bg-alt); color: var(--text-secondary); border: 1px solid var(--border); }
+.tag-amber { background: #fef3e2; color: #b37328; }
+.tag-red { background: #fde8ec; color: #b93e52; }
+.tag-green { background: #e6f7ed; color: #1d7a3f; }
+.tag-purple { background: #eeecfb; color: #5a4dbf; }
+
+/* Stat row */
+.stat-row { display: flex; gap: 24px; }
+.stat { font-size: 12px; color: var(--text-muted); }
+.stat strong { color: var(--text); font-weight: 600; }
+
+/* Tabs */
+.tabs { display: flex; gap: 0; border-bottom: 1px solid var(--border); margin-bottom: 18px; }
+.tab { padding: 10px 18px; font-size: 13px; font-weight: 500; color: var(--text-muted); cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -1px; transition: all 0.15s; background: none; border-top: none; border-left: none; border-right: none; font-family: var(--ff-body); }
+.tab:hover { color: var(--text); }
+.tab.active { color: var(--primary-dark); border-bottom-color: var(--primary); font-weight: 600; }
+.tab-content { display: none; }
+.tab-content.active { display: block; }
+
+/* Data table */
+.data-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.data-table th { text-align: left; font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-muted); padding: 8px 12px; border-bottom: 1px solid var(--border); }
+.data-table td { padding: 10px 12px; border-bottom: 1px solid var(--border-light); color: var(--text-secondary); }
+.data-table tr:last-child td { border-bottom: none; }
+.data-table tr:hover td { background: var(--primary-lighter); }
+.story-id { font-weight: 700; color: var(--primary-dark); font-size: 12px; }
+.story-title { font-weight: 600; color: var(--text); }
+.strength-bar { display: flex; gap: 3px; }
+.str-dot { width: 8px; height: 8px; border-radius: 2px; background: var(--border); }
+.str-dot.filled { background: var(--primary); }
+
+/* Kanban */
+.kanban { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
+.kanban-col-header { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; padding-bottom: 6px; margin-bottom: 6px; border-bottom: 2px solid var(--border); display: flex; align-items: center; justify-content: space-between; }
+.kanban-col-header .cnt { font-size: 9px; background: var(--bg-alt); width: 16px; height: 16px; border-radius: 50%; display: flex; align-items: center; justify-content: center; color: var(--text-muted); }
+.kc-researched .kanban-col-header { border-color: var(--k-researched); color: var(--k-researched); }
+.kc-applied .kanban-col-header { border-color: var(--k-applied); color: var(--k-applied); }
+.kc-interviewing .kanban-col-header { border-color: var(--k-interviewing); color: var(--k-interviewing); }
+.kc-offer .kanban-col-header { border-color: var(--k-offer); color: var(--k-offer); }
+.k-card { background: var(--bg); border: 1px solid var(--border-light); border-radius: var(--radius-sm); padding: 10px; margin-bottom: 6px; border-left: 3px solid var(--border); cursor: pointer; transition: transform 0.12s, box-shadow 0.12s; }
+.k-card:hover { transform: translateY(-1px); box-shadow: var(--shadow-sm); }
+.kc-researched .k-card { border-left-color: var(--k-researched); }
+.kc-applied .k-card { border-left-color: var(--k-applied); }
+.kc-interviewing .k-card { border-left-color: var(--k-interviewing); }
+.kc-offer .k-card { border-left-color: var(--k-offer); }
+.k-card-co { font-size: 13px; font-weight: 700; }
+.k-card-role { font-size: 11px; color: var(--text-muted); margin-top: 1px; }
+.k-card-tag { font-size: 10px; font-weight: 600; padding: 2px 6px; border-radius: var(--radius-xs); margin-top: 5px; display: inline-block; }
+.kanban-empty { font-size: 11px; color: var(--text-muted); text-align: center; padding: 20px 6px; font-style: italic; }
+
+/* Stepper */
+.stepper { display: flex; align-items: center; justify-content: space-between; padding: 8px 0; }
+.step { display: flex; flex-direction: column; align-items: center; gap: 6px; position: relative; flex: 1; }
+.step:not(:last-child)::after { content: ''; position: absolute; top: 13px; left: calc(50% + 15px); right: calc(-50% + 15px); height: 2px; background: var(--border); }
+.step.done:not(:last-child)::after { background: var(--primary); }
+.step-dot { width: 26px; height: 26px; border-radius: 50%; border: 2px solid var(--border); display: flex; align-items: center; justify-content: center; font-size: 10px; font-weight: 700; color: var(--text-muted); background: var(--card); position: relative; z-index: 1; }
+.step.active .step-dot { background: var(--primary); border-color: var(--primary); color: white; box-shadow: 0 0 0 3px var(--primary-light); }
+.step.done .step-dot { background: var(--primary); border-color: var(--primary); color: white; }
+.step-label { font-size: 9px; color: var(--text-muted); text-align: center; }
+.step.active .step-label { color: var(--primary-dark); font-weight: 600; }
+
+/* Action banner */
+.action-banner { background: var(--primary-lighter); border: 1px solid var(--primary-light); border-left: 4px solid var(--primary); border-radius: var(--radius-sm); padding: 14px 18px; display: flex; align-items: center; gap: 12px; margin-top: 14px; }
+.action-icon { width: 34px; height: 34px; background: var(--primary); border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+.action-icon svg { width: 16px; height: 16px; stroke: white; stroke-width: 2; fill: none; }
+.action-text { flex: 1; }
+.action-title { font-size: 13px; font-weight: 700; }
+.action-desc { font-size: 12px; color: var(--text-secondary); margin-top: 1px; }
+
+/* Profile row */
+.profile-row { display: flex; align-items: center; gap: 14px; }
+.profile-avatar { width: 44px; height: 44px; border-radius: 50%; background: var(--primary); color: white; font-size: 15px; font-weight: 700; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+.profile-name { font-size: 17px; font-weight: 700; }
+.profile-role { font-size: 12px; color: var(--text-muted); }
+.profile-tags { display: flex; gap: 6px; margin-left: auto; flex-wrap: wrap; }
+
+/* Chart legend */
+.chart-legend { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 10px; }
+.chart-legend-item { display: flex; align-items: center; gap: 4px; font-size: 11px; color: var(--text-muted); }
+.chart-legend-dot { width: 7px; height: 7px; border-radius: 50%; }
+
+/* Job header */
+.job-header { display: flex; align-items: center; gap: 16px; }
+.job-logo { width: 48px; height: 48px; border-radius: var(--radius-md); background: var(--bg-alt); border: 1px solid var(--border); display: flex; align-items: center; justify-content: center; font-size: 20px; font-weight: 800; color: var(--primary-dark); }
+.job-info { flex: 1; }
+.job-company { font-size: 18px; font-weight: 700; }
+.job-role-title { font-size: 13px; color: var(--text-muted); }
+
+/* Checklist */
+.checklist { list-style: none; }
+.checklist li { display: flex; align-items: center; gap: 10px; padding: 8px 0; font-size: 13px; border-bottom: 1px solid var(--border-light); }
+.checklist li:last-child { border-bottom: none; }
+.check-done { width: 20px; height: 20px; border-radius: 50%; background: var(--primary); display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+.check-done svg { width: 12px; height: 12px; stroke: white; stroke-width: 2.5; fill: none; }
+.check-pending { width: 20px; height: 20px; border-radius: 50%; border: 2px solid var(--border); flex-shrink: 0; }
+
+/* Round timeline */
+.round-timeline { list-style: none; }
+.round-item { display: flex; align-items: flex-start; gap: 12px; padding: 10px 0; position: relative; }
+.round-item:not(:last-child)::after { content: ''; position: absolute; left: 11px; top: 34px; bottom: -2px; width: 2px; background: var(--border-light); }
+.round-dot { width: 24px; height: 24px; border-radius: 50%; border: 2px solid var(--border); display: flex; align-items: center; justify-content: center; font-size: 10px; font-weight: 700; color: var(--text-muted); background: var(--card); flex-shrink: 0; z-index: 1; }
+.round-dot.completed { background: var(--primary); border-color: var(--primary); color: white; }
+.round-dot.upcoming { border-color: var(--c-differentiation); color: var(--c-differentiation); }
+.round-info { flex: 1; }
+.round-name { font-size: 13px; font-weight: 600; }
+.round-meta { font-size: 11px; color: var(--text-muted); }
+
+/* Voice interface */
+.voice-area { display: flex; flex-direction: column; align-items: center; gap: 20px; padding: 40px 20px; }
+.voice-question { text-align: center; max-width: 500px; }
+.voice-question-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px; color: var(--text-muted); margin-bottom: 8px; }
+.voice-question-text { font-family: var(--ff-display); font-size: 22px; line-height: 1.4; }
+.mic-btn { width: 80px; height: 80px; border-radius: 50%; background: var(--primary); border: none; cursor: pointer; display: flex; align-items: center; justify-content: center; transition: transform 0.15s, box-shadow 0.15s; box-shadow: 0 4px 20px rgba(74,158,143,0.3); }
+.mic-btn:hover { transform: scale(1.05); box-shadow: 0 6px 28px rgba(74,158,143,0.4); }
+.mic-btn svg { width: 32px; height: 32px; stroke: white; stroke-width: 1.5; fill: none; }
+.mic-btn.recording { animation: pulse 1.5s ease-in-out infinite; background: #cc4e62; box-shadow: 0 4px 20px rgba(204,78,98,0.3); }
+@keyframes pulse { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.08); } }
+.voice-bars { display: flex; gap: 3px; align-items: center; height: 40px; }
+.voice-bar { width: 4px; border-radius: 2px; background: var(--primary); animation: wave 1s ease-in-out infinite; }
+.voice-bar:nth-child(1) { height: 12px; animation-delay: 0s; }
+.voice-bar:nth-child(2) { height: 20px; animation-delay: 0.1s; }
+.voice-bar:nth-child(3) { height: 30px; animation-delay: 0.2s; }
+.voice-bar:nth-child(4) { height: 24px; animation-delay: 0.3s; }
+.voice-bar:nth-child(5) { height: 16px; animation-delay: 0.4s; }
+.voice-bar:nth-child(6) { height: 28px; animation-delay: 0.15s; }
+.voice-bar:nth-child(7) { height: 18px; animation-delay: 0.25s; }
+@keyframes wave { 0%, 100% { transform: scaleY(1); } 50% { transform: scaleY(0.4); } }
+.voice-timer { font-size: 28px; font-weight: 300; color: var(--text-muted); font-variant-numeric: tabular-nums; }
+.voice-controls { display: flex; gap: 12px; }
+
+/* Scorecard */
+.scorecard { display: grid; grid-template-columns: 200px 1fr; gap: 20px; }
+.score-dims { display: flex; flex-direction: column; gap: 10px; }
+.score-dim { display: flex; align-items: center; gap: 8px; }
+.score-dim-label { font-size: 12px; width: 90px; color: var(--text-secondary); }
+.score-dim-bar { flex: 1; height: 8px; background: var(--bg-alt); border-radius: 4px; overflow: hidden; }
+.score-dim-fill { height: 100%; border-radius: 4px; }
+.score-dim-val { font-size: 12px; font-weight: 700; width: 24px; text-align: right; }
+
+/* Prep section */
+.prep-section h3 { font-size: 15px; font-weight: 700; margin-bottom: 12px; }
+.prep-section p { font-size: 13px; color: var(--text-secondary); line-height: 1.7; margin-bottom: 12px; }
+.prep-list { list-style: none; margin-bottom: 16px; }
+.prep-list li { font-size: 13px; color: var(--text-secondary); padding: 6px 0; border-bottom: 1px solid var(--border-light); display: flex; gap: 8px; }
+.prep-list li:last-child { border-bottom: none; }
+.concern-severity { font-size: 10px; font-weight: 700; padding: 2px 6px; border-radius: var(--radius-xs); }
+
+/* Pattern items */
+.pattern-item { padding: 10px 0; border-bottom: 1px solid var(--border-light); }
+.pattern-item:last-child { border-bottom: none; }
+.pattern-label { font-size: 11px; color: var(--text-muted); margin-bottom: 2px; }
+.pattern-text { font-size: 13px; color: var(--text-secondary); line-height: 1.6; }
+
+/* Materials */
+.material-score { display: flex; align-items: center; gap: 12px; margin-bottom: 16px; }
+.material-score-circle { width: 56px; height: 56px; border-radius: 50%; border: 3px solid var(--primary); display: flex; align-items: center; justify-content: center; font-size: 18px; font-weight: 700; color: var(--primary-dark); }
+.material-dims { flex: 1; display: flex; flex-wrap: wrap; gap: 8px 20px; }
+.material-dim { font-size: 12px; color: var(--text-muted); }
+.material-dim strong { color: var(--text); }
+
+/* Empty state */
+.empty-state { text-align: center; padding: 40px 20px; color: var(--text-muted); }
+.empty-state-icon { width: 48px; height: 48px; background: var(--bg-alt); border-radius: var(--radius-md); display: flex; align-items: center; justify-content: center; margin: 0 auto 12px; }
+.empty-state-icon svg { width: 24px; height: 24px; stroke: var(--text-muted); stroke-width: 1.5; fill: none; }
+.empty-state-title { font-size: 14px; font-weight: 600; color: var(--text); margin-bottom: 4px; }
+.empty-state-desc { font-size: 12px; }
+
+/* Responsive adjustments for page grids */
+@media (max-width: 768px) {
+  .card-grid-2,
+  .card-grid-3,
+  .card-grid-60-40 { grid-template-columns: 1fr; }
+  .kanban { grid-template-columns: repeat(2, 1fr); }
+  .stepper { flex-wrap: wrap; gap: 8px; }
+  .profile-row { flex-wrap: wrap; }
+  .profile-tags { margin-left: 0; }
+  .stat-row { flex-wrap: wrap; gap: 12px; }
+  .job-header { flex-wrap: wrap; }
+  .scorecard { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary
- **7 pages fully implemented** (Tasks 13-19) converting placeholders into production-ready React components matching the `interview-coach-ui-v2.html` reference design
- **7 custom hooks** with mock data for each page (`useDashboard`, `useStories`, `usePractice`, `useMock`, `usePrep`, `useProgress`, `useMaterials`)
- **6 reusable components**: `StoryForm`, `VoiceRecorder`, `Scorecard`, `MockSession`, `ScoreTrendChart`, `ResumeUpload`
- **Shared `pages.css`** with all component styles (cards, tables, kanban, stepper, voice UI, tabs, patterns, materials, empty states)

### Pages
| Page | Key Features |
|------|-------------|
| Dashboard | General view (profile, storybank table, SVG score chart, kanban, drill stepper) + Job view (job header, prep checklist, round timeline) |
| Storybank | Story table with strength bars, add/edit form, gap analysis, narrative identity |
| Practice | 8-stage drill stepper, voice recording with wave animation, 5-dimension scorecard |
| Mock Interview | 6-format selector grid, full voice session flow |
| Interview Prep | 6-tab view (Research/Decode/Brief/Concerns/Questions/Present) |
| Progress | SVG score trend chart with filter chips, calibration display, effective/ineffective patterns |
| Materials | 5-tab view (Resume/LinkedIn/Pitch/Outreach/Salary) with URL param support |

## Test plan
- [x] `tsc --noEmit` passes (zero errors)
- [x] `vite build` succeeds (133 modules)
- [ ] Visual review: `npm run dev` and navigate each page
- [ ] Verify workspace switching changes Dashboard view (General vs Job)
- [ ] Verify Materials `?tab=` URL params work from sidebar links

🤖 Generated with [Claude Code](https://claude.com/claude-code)